### PR TITLE
Insert mode fix due to spelling mistake

### DIFF
--- a/XVim/XVimInsertEvaluator.m
+++ b/XVim/XVimInsertEvaluator.m
@@ -47,7 +47,7 @@
             }
         }
         xvim.mode = MODE_NORMAL;
-        [[xvim sourceView] adjutCursorPosition];
+        [[xvim sourceView] adjustCursorPosition];
         return nil;
     }    
     


### PR DESCRIPTION
There was a crash whenever trying to exit insert mode due to a spelling mistake.
