### PR TITLE
Issue #28: Implement key remapping and .xvimrc.

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		A2F4A34614F00D69006DA5A5 /* XVimSearchLineEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F4A34514F00D69006DA5A5 /* XVimSearchLineEvaluator.m */; };
 		A2FF17D11502B292003FE648 /* XVimMotionEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = A2FF17D01502B291003FE648 /* XVimMotionEvaluator.m */; };
 		A5118D9F14FF64F000C6AFB2 /* Common.m in Sources */ = {isa = PBXBuildFile; fileRef = A5118D9E14FF64F000C6AFB2 /* Common.m */; };
+		C366C23B15287EE30008C58E /* XVimKeymap.m in Sources */ = {isa = PBXBuildFile; fileRef = C366C23A15287EE30008C58E /* XVimKeymap.m */; };
+		C38A5B301526C6B100E1448D /* XVimKeyStroke.m in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B2F1526C6B100E1448D /* XVimKeyStroke.m */; };
 		C38A5B4115272B0500E1448D /* XVimSourceTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B4015272B0500E1448D /* XVimSourceTextView.m */; };
 		C38A5B4715272DCD00E1448D /* XVimSourceCodeEditor.m in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B4615272DCD00E1448D /* XVimSourceCodeEditor.m */; };
 		C38A5B4D1527CEA500E1448D /* XVimNumericEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = C38A5B4C1527CEA400E1448D /* XVimNumericEvaluator.m */; };
@@ -109,6 +111,11 @@
 		A2FF17D01502B291003FE648 /* XVimMotionEvaluator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimMotionEvaluator.m; path = XVim/XVimMotionEvaluator.m; sourceTree = SOURCE_ROOT; };
 		A5118D9D14FF64F000C6AFB2 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Common.h; path = XVim/Common.h; sourceTree = "<group>"; };
 		A5118D9E14FF64F000C6AFB2 /* Common.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Common.m; path = XVim/Common.m; sourceTree = "<group>"; };
+		C366C23715287E080008C58E /* XVimMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimMode.h; path = XVim/XVimMode.h; sourceTree = SOURCE_ROOT; };
+		C366C23915287EE30008C58E /* XVimKeymap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimKeymap.h; path = XVim/XVimKeymap.h; sourceTree = SOURCE_ROOT; };
+		C366C23A15287EE30008C58E /* XVimKeymap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimKeymap.m; path = XVim/XVimKeymap.m; sourceTree = SOURCE_ROOT; };
+		C38A5B2E1526C6B100E1448D /* XVimKeyStroke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimKeyStroke.h; path = XVim/XVimKeyStroke.h; sourceTree = SOURCE_ROOT; };
+		C38A5B2F1526C6B100E1448D /* XVimKeyStroke.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimKeyStroke.m; path = XVim/XVimKeyStroke.m; sourceTree = SOURCE_ROOT; };
 		C38A5B3F15272B0500E1448D /* XVimSourceTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimSourceTextView.h; path = XVim/XVimSourceTextView.h; sourceTree = SOURCE_ROOT; };
 		C38A5B4015272B0500E1448D /* XVimSourceTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimSourceTextView.m; path = XVim/XVimSourceTextView.m; sourceTree = SOURCE_ROOT; };
 		C38A5B4515272DCC00E1448D /* XVimSourceCodeEditor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimSourceCodeEditor.h; path = XVim/XVimSourceCodeEditor.h; sourceTree = SOURCE_ROOT; };
@@ -212,6 +219,11 @@
 				A2B4BAC214D59F6600D817B0 /* Supporting Files */,
 				F17D0139150861DC00A8111B /* XVimRegister.h */,
 				F17D013A150861DC00A8111B /* XVimRegister.m */,
+				C38A5B2E1526C6B100E1448D /* XVimKeyStroke.h */,
+				C38A5B2F1526C6B100E1448D /* XVimKeyStroke.m */,
+				C366C23715287E080008C58E /* XVimMode.h */,
+				C366C23915287EE30008C58E /* XVimKeymap.h */,
+				C366C23A15287EE30008C58E /* XVimKeymap.m */,
 				A2BA3EA0152E372900C18FB4 /* XVimOptions.h */,
 				A2BA3EA1152E372A00C18FB4 /* XVimOptions.m */,
 			);
@@ -381,10 +393,12 @@
 				F17D013B150861DC00A8111B /* XVimRegister.m in Sources */,
 				F100DC2E150BB6BC002C703C /* XVimRegisterEvaluator.m in Sources */,
 				A222B5E11514DFCD005E8802 /* XVimOperatorEvaluator.m in Sources */,
+				C38A5B301526C6B100E1448D /* XVimKeyStroke.m in Sources */,
 				C38A5B4115272B0500E1448D /* XVimSourceTextView.m in Sources */,
 				C38A5B4715272DCD00E1448D /* XVimSourceCodeEditor.m in Sources */,
 				C38A5B4D1527CEA500E1448D /* XVimNumericEvaluator.m in Sources */,
 				C38A5B501527CEE600E1448D /* XVimMotionArgumentEvaluator.m in Sources */,
+				C366C23B15287EE30008C58E /* XVimKeymap.m in Sources */,
 				A2A736381527484B0051E8E4 /* XVimExCommand.m in Sources */,
 				A2A6BA2E152A544C00F0EB5F /* XVimSearch.m in Sources */,
 				A2BA3EA2152E372A00C18FB4 /* XVimOptions.m in Sources */,

--- a/XVim/XVim.h
+++ b/XVim/XVim.h
@@ -9,23 +9,15 @@
 #import <Foundation/Foundation.h>
 #import "XVimCommandLine.h"
 #import "XVimRegister.h"
+#import "XVimMode.h"
 #import "XVimSearch.h"
 #import "XVimExCommand.h"
 #import "XVimOptions.h"
 
 @class XVimEvaluator;
 @class DVTSourceTextView;
+@class XVimKeymap;
 
-typedef enum{
-    MODE_NORMAL,
-    MODE_CMDLINE,
-    MODE_INSERT,
-    MODE_VISUAL
-}XVIM_MODE;
-
-
-static NSString* MODE_STRINGS[] = {@"NORMAL", @"CMDLINE", @"INSERT", 
-    @"VISUAL"};
 
 #define XVIM_TAG 1209 // This is my birthday!
 
@@ -41,6 +33,7 @@ static NSString* MODE_STRINGS[] = {@"NORMAL", @"CMDLINE", @"INSERT",
      NSUInteger _numericArgument;
      XVimEvaluator* _currentEvaluator;
      NSMutableDictionary* _localMarks; // key = single letter mark name. value = NSRange (wrapped in a NSValue) for mark location
+	 XVimKeymap* _keymaps[MODE_COUNT];
 }
 
 @property NSInteger tag;
@@ -82,6 +75,7 @@ static NSString* MODE_STRINGS[] = {@"NORMAL", @"CMDLINE", @"INSERT",
 - (void)recordIntoRegister:(XVimRegister*)xregister;
 - (void)stopRecordingRegister:(XVimRegister*)xregister;
 - (void)playbackRegister:(XVimRegister*)xregister withRepeatCount:(NSUInteger)count;
+- (XVimKeymap*)keymapForMode:(int)mode;
 
 // Option handlings( Not implemented yet )
 /*

--- a/XVim/XVim.m
+++ b/XVim/XVim.m
@@ -36,9 +36,11 @@
 #import "XVimSearch.h"
 #import "XVimNormalEvaluator.h"
 #import "NSTextView+VimMotion.h"
+#import "XVimKeyStroke.h"
+#import "XVimKeymap.h"
 
 @interface XVim()
-- (void)recordEvent:(NSEvent*)event intoRegister:(XVimRegister*)xregister;
+- (void)recordEvent:(XVimKeyStroke*)keyStroke intoRegister:(XVimRegister*)xregister;
 @property (strong) NSString *searchCharacter;
 @end
 
@@ -82,7 +84,6 @@
     //[Logger registerTracing:@"DVTSourceTextView"];
     //[Logger registerTracing:@"DVTTextFinder"];
     //[Logger registerTracing:@"DVTIncrementalFindBar"];
-    
 }
 
 + (void) hook
@@ -180,6 +181,15 @@
         _searchCharacter = @"";
         _shouldSearchCharacterBackward = NO;
         _shouldSearchPreviousCharacter = NO;
+		
+		for (int i = 0; i < MODE_COUNT; ++i)
+		{
+			_keymaps[i] = [[XVimKeymap alloc] init];
+		}
+		[XVimKeyStroke initKeymaps];
+		
+		// Must be last since ex commands can use self
+		[self parseRcFile];
     }
     
     return self;
@@ -219,25 +229,49 @@
     return [[self sourceView] selectedRange];
 }
 
-- (BOOL)handleKeyEvent:(NSEvent*)event{
-    XVimEvaluator* nextEvaluator = [_currentEvaluator eval:event ofXVim:self];
-    [self recordEvent:event intoRegister:_recordingRegister];
-    [self recordEvent:event intoRegister:[self findRegister:@"repeat"]];
-    if( nil == nextEvaluator ){
-        nextEvaluator = [[XVimNormalEvaluator alloc] init];
-    }
-    
-    if( _currentEvaluator != nextEvaluator ){
-        [_currentEvaluator release];
-        _currentEvaluator = nextEvaluator;
+- (void)parseRcFile {
+    NSString *homeDir = NSHomeDirectoryForUser(NSUserName());
+    NSString *keymapPath = [homeDir stringByAppendingString: @"/.xvimrc"]; 
+    NSString *keymapData = [[NSString alloc] initWithContentsOfFile:keymapPath 
+                                                           encoding:NSUTF8StringEncoding
+															  error:NULL];
+	for (NSString *string in [keymapData componentsSeparatedByString:@"\n"])
+	{
+		[self.excmd executeCommand:[@":" stringByAppendingString:string]];
+	}
+}
 
-        XVIM_MODE newMode = [_currentEvaluator becameHandler:self];
-        if (self.mode != MODE_CMDLINE){
-            // Special case for cmdline mode. I don't like this, but
-            // don't have time to refactor cmdline mode.
-            self.mode = newMode;
-        }
-    }
+- (XVimKeymap*)keymapForMode:(int)mode {
+	return _keymaps[mode];
+}
+
+- (BOOL)handleKeyEvent:(NSEvent*)event{
+	
+	XVimKeyStroke* keyStroke = [XVimKeyStroke fromEvent:event];
+	XVimKeymap* keymap = [_currentEvaluator selectKeymap:_keymaps];
+	NSArray *keystrokes = [keymap lookupKeyStroke:keyStroke];
+	
+	for (XVimKeyStroke *keyStroke in keystrokes)
+	{
+		XVimEvaluator* nextEvaluator = [_currentEvaluator eval:keyStroke ofXVim:self];
+		[self recordEvent:keyStroke intoRegister:_recordingRegister];
+		[self recordEvent:keyStroke intoRegister:[self findRegister:@"repeat"]];
+		if( nil == nextEvaluator ){
+			nextEvaluator = [[XVimNormalEvaluator alloc] init];
+		}
+		
+		if( _currentEvaluator != nextEvaluator ){
+			[_currentEvaluator release];
+			_currentEvaluator = nextEvaluator;
+			
+			XVIM_MODE newMode = [_currentEvaluator becameHandler:self];
+			if (self.mode != MODE_CMDLINE){
+				// Special case for cmdline mode. I don't like this, but
+				// don't have time to refactor cmdline mode.
+				self.mode = newMode;
+			}
+		}
+	}
     
     [self.cmdLine setNeedsDisplay:YES];
     return YES;
@@ -446,15 +480,15 @@
     }
 }
 
-- (void)recordEvent:(NSEvent*)event intoRegister:(XVimRegister*)xregister{
-    switch ([_currentEvaluator shouldRecordEvent:event inRegister:xregister]) {
+- (void)recordEvent:(XVimKeyStroke*)keyStroke intoRegister:(XVimRegister*)xregister{
+    switch ([_currentEvaluator shouldRecordEvent:keyStroke inRegister:xregister]) {
         case REGISTER_APPEND:
-            [xregister appendKeyEvent:event];
+            [xregister appendKeyEvent:keyStroke];
             break;
             
         case REGISTER_REPLACE:
             [xregister clear];
-            [xregister appendKeyEvent:event];
+            [xregister appendKeyEvent:keyStroke];
             break;
             
         case REGISTER_IGNORE:

--- a/XVim/XVimEvaluator.h
+++ b/XVim/XVimEvaluator.h
@@ -39,6 +39,8 @@ An evaluator which takes argument to determine the motion ( like 'f' ) use XVimM
 #import "XVim.h"
 
 @class XVimMotionEvaluator;
+@class XVimKeyStroke;
+@class XVimKeymap;
 @class DVTSourceTextView;
 
 typedef enum {
@@ -48,14 +50,14 @@ typedef enum {
 } XVimMarkOperator;
 
 @interface XVimEvaluator : NSObject
-+ (NSString*) keyStringFromKeyEvent:(NSEvent*)event;
-- (XVimEvaluator*)eval:(NSEvent*) event ofXVim:(XVim*)xvim;
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim;
+- (XVimKeymap*)selectKeymap:(XVimKeymap**)keymaps;
 - (XVimEvaluator*)defaultNextEvaluator;
 // Made into a property so it can be set 
 @property (weak) XVim *xvim;
 @property (readonly) DVTSourceTextView *textView;
 @property (readonly) NSUInteger insertionPoint;
 
-- (XVimRegisterOperation)shouldRecordEvent:(NSEvent*) event inRegister:(XVimRegister*)xregister;
+- (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*)keyStroke inRegister:(XVimRegister*)xregister;
 - (XVIM_MODE)becameHandler:(XVim*)xvim;
 @end

--- a/XVim/XVimEvaluator.m
+++ b/XVim/XVimEvaluator.m
@@ -9,139 +9,9 @@
 #import "XVimEvaluator.h"
 #import "XVimMotionEvaluator.h"
 #import "NSTextView+VimMotion.h"
+#import "XVimKeyStroke.h"
 #import "Logger.h"
 #import "XVim.h"
-    
-static char* keynames[] = {
-    "NUL",
-    "SOH",
-    "STX",
-    "ETX",
-    "EOT",
-    "ENQ",
-    "ACK",
-    "BEL",
-    "BS",
-    "HT",
-    "NL",
-    "VT",
-    "NP",
-    "CR",
-    "SO",
-    "SI",
-    "DLE",
-    "DC1",
-    "DC2",
-    "DC3",
-    "DC4",
-    "NAK",
-    "SYN",
-    "ETB",
-    "CAN",
-    "EM",
-    "SUB",
-    "ESC",
-    "FS",
-    "GS",
-    "RS",
-    "US",
-    "SP",
-    "EXCLAMATION",
-    "DQUOTE",
-    "NUMBER",
-    "DOLLAR",
-    "PERCENT",
-    "AMPERSAND",
-    "SQUOTE",
-    "LPARENTHESIS",
-    "RPARENTHESIS",
-    "ASTERISK",
-    "PLUS",
-    "COMMA",
-    "MINUS",
-    "DOT",
-    "SLASH",
-    "NUM0",
-    "NUM1",
-    "NUM2",
-    "NUM3",
-    "NUM4",
-    "NUM5",
-    "NUM6",
-    "NUM7",
-    "NUM8",
-    "NUM9",
-    "COLON",
-    "SEMICOLON",
-    "LESSTHAN",
-    "EQUAL",
-    "GREATERTHAN",
-    "QUESTION",
-    "AT",
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F",
-    "G",
-    "H",
-    "I",
-    "J",
-    "K",
-    "L",
-    "M",
-    "N",
-    "O",
-    "P",
-    "Q",
-    "R",
-    "S",
-    "T",
-    "U",
-    "V",
-    "W",
-    "X",
-    "Y",
-    "Z",
-    "LSQUAREBRACKET",
-    "BACKSLASH",
-    "RSQUAREBRACKET",
-    "CARET",
-    "UNDERSCORE",
-    "BACKQUOTE",
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "g",
-    "h",
-    "i",
-    "j",
-    "k",
-    "l",
-    "m",
-    "n",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "t",
-    "u",
-    "v",
-    "w",
-    "x",
-    "y",
-    "z",
-    "LBRACE", // {
-    "VERTICALLINE", // |
-    "RBRACE", // }
-    "TILDE", // ~
-    "DEL"
-};
 
 @implementation XVimEvaluator
 
@@ -157,45 +27,7 @@ static char* keynames[] = {
     return MODE_NORMAL;
 }
 
-+ (NSString*) keyStringFromKeyEvent:(NSEvent*)event{
-    // S- Shift
-    // C- Control
-    // M- Option
-    // D- Command
-    NSMutableString* keyStr = [[[NSMutableString alloc] init] autorelease];
-    if( [event modifierFlags] & NSShiftKeyMask ){
-        // implement later
-    }
-    if( [event modifierFlags] & NSControlKeyMask ){
-        [keyStr appendString:@"C_"];
-    }
-    if( [event modifierFlags] & NSAlternateKeyMask ){
-        [keyStr appendString:@"M_"];
-    }
-    if( [event modifierFlags] & NSCommandKeyMask ){
-        [keyStr appendString:@"D_"];
-    }
-    
-    unichar charcode = [[event charactersIgnoringModifiers] characterAtIndex:0];    
-    if( 0 <= charcode && charcode <= 127 ){
-        char* keyname = keynames[charcode];
-        [keyStr appendFormat:[NSString stringWithCString:keyname encoding:NSASCIIStringEncoding]];
-    }
-    else if ( charcode == 63232 ){
-        [keyStr appendString:@"Up"];
-    }
-    else if ( charcode == 63233 ){
-        [keyStr appendString:@"Down"];
-    }
-    else if ( charcode == 63234 ){
-        [keyStr appendString:@"Left"];
-    }
-    else if ( charcode == 63235 ){
-        [keyStr appendString:@"Right"];
-    }
-       
-    return keyStr;
-}
+
 
 - (id)init
 {
@@ -208,23 +40,27 @@ static char* keynames[] = {
 }
 
 
-- (XVimEvaluator*)eval:(NSEvent*)event ofXVim:(XVim*)xvim{
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim{
     // This is default implementation of evaluator.
-    // Only keyDown event supporsed to be passed here.
-    NSString* key = [XVimEvaluator keyStringFromKeyEvent:event];
-    
+    // Only keyDown events are supposed to be passed here.	
     // Invokes each key event handler
     // <C-k> invokes "C_k:" selector
-    // each method returns next evaluator(maybe self or maybe another evaluator )
-    SEL handler = NSSelectorFromString([key stringByAppendingString:@":"]);
-    if( [self respondsToSelector:handler] ){
-        TRACE_LOG(@"Calling SELECTOR %@", NSStringFromSelector(handler));
+	
+	SEL handler = [keyStroke selectorForInstance:self];
+	if (handler)
+	{
+		TRACE_LOG(@"Calling SELECTOR %@", NSStringFromSelector(handler));
         return [self performSelector:handler withObject:nil];
-    }
+	}
     else{
         TRACE_LOG(@"SELECTOR %@ not found", NSStringFromSelector(handler));
         return [self defaultNextEvaluator];
     }
+}
+
+- (XVimKeymap*)selectKeymap:(XVimKeymap**)keymaps
+{
+	return keymaps[MODE_GLOBAL_MAP];
 }
 
 - (XVimEvaluator*)defaultNextEvaluator{
@@ -235,7 +71,7 @@ static char* keynames[] = {
     return [self.xvim sourceView];
 }
 
-- (XVimRegisterOperation)shouldRecordEvent:(NSEvent*) event inRegister:(XVimRegister*)xregister{
+- (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*)keyStroke inRegister:(XVimRegister*)xregister{
     if (xregister.isReadOnly){
         return REGISTER_IGNORE;
     }

--- a/XVim/XVimKeyStroke.h
+++ b/XVim/XVimKeyStroke.h
@@ -1,0 +1,25 @@
+//
+//  XVimKeyStroke.h
+//  XVim
+//
+//  Created by Tomas Lundell on 31/03/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface XVimKeyStroke : NSObject<NSCopying>
++ (void)initKeymaps;
++ (XVimKeyStroke*)fromString:(NSString *)string;
++ (void)fromString:(NSString *)string to:(NSMutableArray *)keystrokest;
++ (XVimKeyStroke*)fromEvent:(NSEvent*)event;
+- (NSEvent*)toEvent;
+- (NSString*)toSelectorString;
+- (SEL)selectorForInstance:(id)target;
+- (BOOL)instanceResponds:(id)target;
+- (BOOL)classResponds:(Class)class;
+- (XVimKeyStroke*)keyStrokeByStrippingModifiers;
+
+@property (nonatomic) unichar key;
+@property (nonatomic) int modifierFlags;
+@end

--- a/XVim/XVimKeyStroke.m
+++ b/XVim/XVimKeyStroke.m
@@ -1,0 +1,432 @@
+//
+//  XVimKeyStroke.m
+//  XVim
+//
+//  Created by Tomas Lundell on 31/03/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "XVimKeyStroke.h"
+
+static char* keynames[] = {
+    "NUL",
+    "SOH",
+    "STX",
+    "ETX",
+    "EOT",
+    "ENQ",
+    "ACK",
+    "BEL",
+    "BS",
+    "HT",
+    "NL",
+    "VT",
+    "NP",
+    "CR",
+    "SO",
+    "SI",
+    "DLE",
+    "DC1",
+    "DC2",
+    "DC3",
+    "DC4",
+    "NAK",
+    "SYN",
+    "ETB",
+    "CAN",
+    "EM",
+    "SUB",
+    "ESC",
+    "FS",
+    "GS",
+    "RS",
+    "US",
+    "SPACE",
+    "EXCLAMATION",
+    "DQUOTE",
+    "NUMBER",
+    "DOLLAR",
+    "PERCENT",
+    "AMPERSAND",
+    "SQUOTE",
+    "LPARENTHESIS",
+    "RPARENTHESIS",
+    "ASTERISK",
+    "PLUS",
+    "COMMA",
+    "MINUS",
+    "DOT",
+    "SLASH",
+    "NUM0",
+    "NUM1",
+    "NUM2",
+    "NUM3",
+    "NUM4",
+    "NUM5",
+    "NUM6",
+    "NUM7",
+    "NUM8",
+    "NUM9",
+    "COLON",
+    "SEMICOLON",
+    "LESSTHAN",
+    "EQUAL",
+    "GREATERTHAN",
+    "QUESTION",
+    "AT",
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "H",
+    "I",
+    "J",
+    "K",
+    "L",
+    "M",
+    "N",
+    "O",
+    "P",
+    "Q",
+    "R",
+    "S",
+    "T",
+    "U",
+    "V",
+    "W",
+    "X",
+    "Y",
+    "Z",
+    "LSQUAREBRACKET",
+    "BACKSLASH",
+    "RSQUAREBRACKET",
+    "CARET",
+    "UNDERSCORE",
+    "BACKQUOTE",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+    "LBRACE", // {
+    "VERTICALLINE", // |
+    "RBRACE", // }
+    "TILDE", // ~
+    "DEL"
+};
+
+static NSMutableDictionary *s_keyCodeToSelectorString = NULL;
+static NSMutableDictionary *s_stringToKeyCode = NULL;
+
+@implementation XVimKeyStroke
+@synthesize key;
+@synthesize modifierFlags;
+
++ (void)initKeyCodeToSelectorString
+{
+	if (!s_keyCodeToSelectorString)
+	{
+		NSMutableDictionary *keyCodeToSelectorString = [[NSMutableDictionary alloc] init];
+		s_keyCodeToSelectorString = keyCodeToSelectorString;
+		
+		void (^map) (NSString *, int) = ^(NSString *key, int i)
+		{
+			[keyCodeToSelectorString setObject:key forKey:[NSNumber numberWithInt:i]];
+		};
+		
+		for (int i = 0; i < 128; ++i)
+		{
+			NSString *string = [NSString stringWithCString:keynames[i] encoding:NSASCIIStringEncoding];
+			map(string, i);
+		}
+		
+		map(@"Up", 63232);
+		map(@"Down", 63233);
+		map(@"Left", 63234);
+		map(@"Right", 63235);
+	}
+}
+
++ (void)initStringToKeyCode
+{
+	if (!s_stringToKeyCode)
+	{
+		NSMutableDictionary *stringToKeyCode = [[NSMutableDictionary alloc] init];
+		s_stringToKeyCode = stringToKeyCode;
+		
+		void (^map) (NSString *, int) = ^(NSString *key, int i)
+		{
+			[stringToKeyCode setObject:[NSNumber numberWithInt:i] forKey:key];
+		};
+		
+		// Map the selector names - we uppercase all of these to make them case insensitive
+		for (int i = 0; i <= 32; ++i)
+		{
+			NSString *string = [NSString stringWithCString:keynames[i] encoding:NSASCIIStringEncoding];
+			map([string uppercaseString], i);
+		}
+		map(@"UP", 63232);
+		map(@"DOWN", 63233);
+		map(@"LEFT", 63234);
+		map(@"RIGHT", 63235);
+		
+		// Between space and del (non-inclusive), add ascii names
+		for (int i = 33; i < 127; ++i)
+		{
+			unichar c = i;
+			NSString *string = [NSString stringWithCharacters:&c length:1];
+			map(string, i);
+		}
+	}
+}
+
++ (void)initKeymaps
+{
+	[self initKeyCodeToSelectorString];
+	[self initStringToKeyCode];
+}
+
+- (NSUInteger)hash
+{
+	return self.modifierFlags + self.key;
+}
+
+- (BOOL)isEqual:(id)object
+{
+	if (object == self) {
+		return YES;
+	}	
+	if (!object || ![object isKindOfClass:[self class]])
+	{
+		return NO;
+	}
+	XVimKeyStroke* other = object;
+	return self.key == other.key && self.modifierFlags == other.modifierFlags;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+	XVimKeyStroke* copy = [[XVimKeyStroke allocWithZone:zone] init];
+	copy.key = self.key;
+	copy.modifierFlags = self.modifierFlags;
+	return copy;
+}
+
++ (XVimKeyStroke*)fromEvent:(NSEvent*)event
+{
+	XVimKeyStroke *keyStroke = [[XVimKeyStroke alloc] init];
+	keyStroke.key = [event.characters characterAtIndex:0];
+	keyStroke.modifierFlags = event.modifierFlags & 
+		(NSShiftKeyMask | NSControlKeyMask | NSCommandKeyMask | NSAlternateKeyMask);
+	return keyStroke;
+}
+
+- (NSEvent*)toEvent
+{
+	unichar c = self.key;
+	NSString *characters = [NSString stringWithCharacters:&c length:1];
+	int mflags = self.modifierFlags;
+	
+	NSEvent*  e = [NSEvent keyEventWithType:NSKeyDown 
+								   location:NSMakePoint(0, 0)
+							  modifierFlags:mflags
+								  timestamp:0
+							   windowNumber:0
+									context:nil
+								 characters:characters
+				charactersIgnoringModifiers:characters
+								  isARepeat:NO 
+									keyCode:0];
+	return e;
+}
+
+static NSString* toSelectorString(unichar charcode, int modifierFlags)
+{
+	// S- Shift
+	// C- Control
+	// M- Option
+	// D- Command
+	NSMutableString* keyStr = [[[NSMutableString alloc] init] autorelease];
+	if( modifierFlags & NSShiftKeyMask ){
+		[keyStr appendString:@"S_"];
+	}
+	if( modifierFlags & NSControlKeyMask ){
+		[keyStr appendString:@"C_"];
+	}
+	if( modifierFlags & NSAlternateKeyMask ){
+		[keyStr appendString:@"M_"];
+	}
+	if( modifierFlags & NSCommandKeyMask ){
+		[keyStr appendString:@"D_"];
+	}
+	
+	NSString *keyname = [s_keyCodeToSelectorString objectForKey:[NSNumber numberWithInt:charcode]];
+	if (keyname) { 
+		[keyStr appendString:keyname];
+	}
+	
+	return keyStr;
+}
+
+- (NSString*) toSelectorString {
+	return toSelectorString(self.key, self.modifierFlags);
+}
+
+- (NSString*)description {
+	return [self toSelectorString];
+}
+
+static int stripModifiers(int modifierFlags)
+{
+	return modifierFlags & ~(NSShiftKeyMask | NSAlternateKeyMask);
+}
+
+static SEL getSelector(unichar charcode, int modifierFlags)
+{
+	NSString* keyString = toSelectorString(charcode, modifierFlags);
+	SEL selector = NSSelectorFromString([keyString stringByAppendingString:@":"]);
+	return selector;
+}
+
+static SEL matchSingleHandler(id target, unichar charcode, int modifierFlags)
+{
+	SEL selector = getSelector(charcode, modifierFlags);
+	BOOL responds = [target respondsToSelector:selector];
+	return responds ? selector : NULL;
+}
+
+- (SEL) selectorForInstance:(id)target {
+	SEL handler = NULL;
+	
+	handler = handler ? handler : matchSingleHandler(target, self.key, self.modifierFlags);
+	handler = handler ? handler : matchSingleHandler(target, self.key, stripModifiers(self.modifierFlags));
+		
+	return handler;
+}
+
+- (XVimKeyStroke*)keyStrokeByStrippingModifiers
+{
+	XVimKeyStroke* newKeyStroke = [[XVimKeyStroke alloc] init];
+	newKeyStroke.key = self.key;
+	newKeyStroke.modifierFlags = stripModifiers(self.modifierFlags);
+	return newKeyStroke;
+}
+
+- (BOOL)instanceResponds:(id)target
+{
+	return [self selectorForInstance:target] != NULL;
+}
+
+- (BOOL)classResponds:(Class)class
+{
+	return [class instancesRespondToSelector:getSelector(self.key, self.modifierFlags)] || 
+	[class instancesRespondToSelector:getSelector(self.key, stripModifiers(self.modifierFlags))];
+}
+
++ (XVimKeyStroke *)fromString:(NSString *)string from:(int*)index
+{
+	int starti = *index;
+	int endi = starti;
+	NSString *keyString = NULL;
+	
+	int modifierFlags = 0;
+	if ([string characterAtIndex:starti] == '<')
+	{
+		// Find modifier flags, if any
+		{
+			NSString *uppercaseString = [[string substringFromIndex:starti+1] uppercaseString];
+			
+			if ([uppercaseString hasPrefix:@"S-"])
+			{
+				modifierFlags = NSShiftKeyMask;
+			}
+			if ([uppercaseString hasPrefix:@"C-"])
+			{
+				modifierFlags = NSControlKeyMask;
+			}
+			if ([uppercaseString hasPrefix:@"M-"])
+			{
+				modifierFlags = NSAlternateKeyMask;
+			}
+			if ([uppercaseString hasPrefix:@"D-"])
+			{
+				modifierFlags = NSCommandKeyMask;
+			}
+		}
+		
+		NSRange searchRange = {starti, string.length - starti};
+		NSRange keyStringEndRange = [string rangeOfString:@">" options:0 range:searchRange];
+		
+		int keyStringStarti = starti + 1 + (modifierFlags ? 2 : 0);
+		int keyStringEndi = keyStringEndRange.location;
+		
+		endi = keyStringEndi + 1; // Skip > char
+		
+		NSRange keyStringRange = {keyStringStarti, keyStringEndi - keyStringStarti};
+		keyString = [string substringWithRange:keyStringRange];
+	} else {
+		endi = starti + 1;
+		
+		NSRange keyStringRange = {starti, endi - starti};
+		keyString = [string substringWithRange:keyStringRange];
+	}
+	
+	NSNumber *number = NULL;
+	number = number ? number : [s_stringToKeyCode objectForKey:keyString];
+	number = number ? number : [s_stringToKeyCode objectForKey:[keyString uppercaseString]];
+	
+	XVimKeyStroke *keyStroke = NULL;
+	if (number)
+	{
+		keyStroke = [[XVimKeyStroke alloc] init];
+		keyStroke->key = [number intValue];
+		keyStroke->modifierFlags = modifierFlags;
+	}
+	
+	*index = endi;
+	return keyStroke;
+}
+
++ (XVimKeyStroke*)fromString:(NSString *)string
+{
+	int index = 0;
+	XVimKeyStroke *keyStroke = [self fromString:string from:&index];
+	return keyStroke;
+}
+
++ (void)fromString:(NSString *)string to:(NSMutableArray *)keystrokes
+{
+	int index = 0;
+	int len = string.length;
+	while (index < len)
+	{
+		XVimKeyStroke* keyStroke = [self fromString:string from:&index];
+		if (keyStroke == NULL) { break; }
+		[keystrokes addObject:keyStroke];
+	}
+}
+
+@end

--- a/XVim/XVimKeymap.h
+++ b/XVim/XVimKeymap.h
@@ -1,0 +1,16 @@
+//
+//  XVimKeymap.h
+//  XVim
+//
+//  Created by Tomas Lundell on 1/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class XVimKeyStroke;
+
+@interface XVimKeymap : NSObject
+- (void)mapKeyStroke:(XVimKeyStroke*)keyStroke to:(NSArray*)targetKeyStrokes;
+- (NSArray*)lookupKeyStroke:(XVimKeyStroke*)keyStroke;
+@end

--- a/XVim/XVimKeymap.m
+++ b/XVim/XVimKeymap.m
@@ -1,0 +1,43 @@
+//
+//  XVimKeymap.m
+//  XVim
+//
+//  Created by Tomas Lundell on 1/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "XVimKeymap.h"
+#import "XVimKeyStroke.h"
+
+@interface XVimKeymap() {
+	__strong NSMutableDictionary *_dict;
+}
+@end
+
+@implementation XVimKeymap
+- (id)init
+{
+	self = [super init];
+	if (self) {
+		_dict = [[NSMutableDictionary alloc] init];
+	}
+	return self;
+}
+
+- (void)mapKeyStroke:(XVimKeyStroke*)keyStroke to:(NSArray*)targetKeyStrokes
+{
+	[_dict setObject:targetKeyStrokes forKey:keyStroke];
+}
+
+- (NSArray*)lookupKeyStroke:(XVimKeyStroke*)keyStroke
+{
+	NSArray* ret = NULL;
+	
+	ret = ret ? ret : [_dict objectForKey:keyStroke];
+	ret = ret ? ret : [_dict objectForKey:[keyStroke keyStrokeByStrippingModifiers]];
+	ret = ret ? ret : [NSArray arrayWithObject:keyStroke];
+	
+	return ret;
+}
+
+@end

--- a/XVim/XVimLocalMarkEvaluator.m
+++ b/XVim/XVimLocalMarkEvaluator.m
@@ -7,6 +7,7 @@
 //
 
 #import "XVimLocalMarkEvaluator.h"
+#import "XVimKeyStroke.h"
 
 @implementation XVimLocalMarkEvaluator
 
@@ -24,9 +25,9 @@
     return self;
 }
 
-- (XVimEvaluator*)eval:(NSEvent*)event ofXVim:(XVim*)xvim{
-    NSString* keyStr = [XVimEvaluator keyStringFromKeyEvent:event];
-    if ([keyStr length] != 1) {
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim{
+    NSString* keyStr = [keyStroke toSelectorString];
+	if ([keyStr length] != 1) {
         return nil;
     }
     unichar c = [keyStr characterAtIndex:0];

--- a/XVim/XVimMode.h
+++ b/XVim/XVimMode.h
@@ -1,0 +1,20 @@
+//
+//  XVimMode.h
+//  XVim
+//
+//  Created by Tomas Lundell on 1/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+typedef enum {
+    MODE_NORMAL,
+    MODE_CMDLINE,
+    MODE_INSERT,
+    MODE_VISUAL,
+	MODE_OPERATOR_PENDING,
+	MODE_GLOBAL_MAP,
+	MODE_COUNT,
+} XVIM_MODE;
+
+static NSString* MODE_STRINGS[] = {@"NORMAL", @"CMDLINE", @"INSERT", 
+    @"VISUAL", @"OPERATOR"};

--- a/XVim/XVimMotionEvaluator.m
+++ b/XVim/XVimMotionEvaluator.m
@@ -11,6 +11,7 @@
 #import "XVimGEvaluator.h"
 #import "XVimZEvaluator.h"
 #import "XVimLocalMarkEvaluator.h"
+#import "XVimKeyStroke.h"
 #import "XVim.h"
 #import "Logger.h"
 #import "XVimYankEvaluator.h"
@@ -480,7 +481,7 @@
 /* 
  * Space acts like 'l' in vi. moves  cursor forward
  */
-- (XVimEvaluator*)SP:(id)arg{
+- (XVimEvaluator*)SPACE:(id)arg{
     return [self l:arg];
 }
 
@@ -836,12 +837,11 @@
     return [self l:(id)arg];
 }
 
-- (XVimRegisterOperation)shouldRecordEvent:(NSEvent*) event inRegister:(XVimRegister*)xregister{
+- (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*) keyStroke inRegister:(XVimRegister*)xregister{
     if (xregister.isRepeat){
         if (xregister.nonNumericKeyCount == 1){
-            NSString *key = [XVimEvaluator keyStringFromKeyEvent:event];
-            SEL handler = NSSelectorFromString([key stringByAppendingString:@":"]);
-            if([[XVimMotionEvaluator class] instancesRespondToSelector:handler] || [key hasPrefix:@"NUM"]){
+            NSString *key = [keyStroke toSelectorString];
+            if([keyStroke classResponds:[XVimMotionEvaluator class]] || [key hasPrefix:@"NUM"]){
                 return REGISTER_APPEND;
             }
         }
@@ -849,7 +849,7 @@
         return REGISTER_IGNORE;
     }
     
-    return [super shouldRecordEvent:event inRegister:xregister];
+    return [super shouldRecordEvent:keyStroke inRegister:xregister];
 }
 
 @end

--- a/XVim/XVimNumericEvaluator.m
+++ b/XVim/XVimNumericEvaluator.m
@@ -7,6 +7,7 @@
 //
 
 #import "XVimNumericEvaluator.h"
+#import "XVimKeyStroke.h"
 
 @implementation XVimNumericEvaluator
 @synthesize numericMode,numericArg;
@@ -20,8 +21,8 @@
     return self;
 }
 
-- (XVimEvaluator*)eval:(NSEvent*)event ofXVim:(XVim*)xvim{
-    NSString* keyStr = [XVimEvaluator keyStringFromKeyEvent:event];
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim{
+    NSString* keyStr = [keyStroke toSelectorString];
     if( [keyStr hasPrefix:@"NUM"] ){
         if( self.numericMode ){
             NSString* numStr = [keyStr substringFromIndex:3];
@@ -44,7 +45,7 @@
         }
     }
     
-    XVimEvaluator *nextEvaluator = [super eval:event ofXVim:xvim];
+    XVimEvaluator *nextEvaluator = [super eval:keyStroke ofXVim:xvim];
     [self resetNumericArg]; // Reset the numeric arg after evaluating an event
     return nextEvaluator;
 }

--- a/XVim/XVimOperatorEvaluator.m
+++ b/XVim/XVimOperatorEvaluator.m
@@ -8,9 +8,15 @@
 
 #import "NSTextView+VimMotion.h"
 #import "XVimOperatorEvaluator.h"
+#import "XVimKeyStroke.h"
 #import "Logger.h"
 
 @implementation XVimOperatorEvaluator
+
+- (XVimKeymap*)selectKeymap:(XVimKeymap**)keymaps
+{
+	return keymaps[MODE_OPERATOR_PENDING];
+}
 
 - (void)selectOperationTargetFrom:(NSUInteger)from To:(NSUInteger)to Type:(MOTION_TYPE)type {
     if( from > to ){
@@ -56,10 +62,9 @@
     }
 }
 
-- (XVimRegisterOperation)shouldRecordEvent:(NSEvent*) event inRegister:(XVimRegister*)xregister{
-    NSString *key = [XVimEvaluator keyStringFromKeyEvent:event];
-    SEL handler = NSSelectorFromString([key stringByAppendingString:@":"]);
-    if([self respondsToSelector:handler] || [key hasPrefix:@"NUM"]){
+- (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*) keyStroke inRegister:(XVimRegister*)xregister{
+    NSString *key = [keyStroke toSelectorString];
+    if([keyStroke instanceResponds:self] || [key hasPrefix:@"NUM"]){
         TRACE_LOG(@"REGISTER_APPEND");
         return REGISTER_APPEND;
     }

--- a/XVim/XVimRegister.h
+++ b/XVim/XVimRegister.h
@@ -14,12 +14,14 @@ typedef enum {
     REGISTER_REPLACE
 } XVimRegisterOperation;
 
+@class XVimKeyStroke;
+
 @interface XVimRegister : NSObject
 
 -(id) initWithRegisterName:(NSString*)name;
 
 -(void) playback:(NSView*)view withRepeatCount:(NSUInteger)count;
--(void) appendKeyEvent:(NSEvent*)event;
+-(void) appendKeyEvent:(XVimKeyStroke*)keyStroke;
 -(void) appendText:(NSString*)text;
 -(void) clear;
 

--- a/XVim/XVimRegister.m
+++ b/XVim/XVimRegister.m
@@ -8,6 +8,7 @@
 
 #import "XVimRegister.h"
 #import "XVimEvaluator.h"
+#import "XVimKeyStroke.h"
 #import <CoreServices/CoreServices.h>
 
 @interface XVimRegister()
@@ -93,12 +94,12 @@
     [self.keyEventsAndInsertedText removeAllObjects];
 }
 
--(void) appendKeyEvent:(NSEvent*)event{
+-(void) appendKeyEvent:(XVimKeyStroke*)keyStroke{
     if (self.isPlayingBack){
         return;
     }
 
-    NSString *key = [XVimEvaluator keyStringFromKeyEvent:event];
+    NSString *key = [keyStroke toSelectorString];
     if (key.length > 1){
         [self.text appendString:[NSString stringWithFormat:@"<%@>", key]];
     }else{
@@ -107,7 +108,7 @@
     if ([key hasPrefix:@"NUM"] == NO){
         ++_nonNumericKeyCount;
     }
-    [self.keyEventsAndInsertedText addObject:event];
+    [self.keyEventsAndInsertedText addObject:keyStroke];
 }
 
 -(void) appendText:(NSString*)text{
@@ -123,9 +124,10 @@
     self.isPlayingBack = YES;
     for (NSUInteger i = 0; i < count; ++i) {
         [self.keyEventsAndInsertedText enumerateObjectsUsingBlock:^(id eventOrText, NSUInteger index, BOOL *stop){        
-            if ([eventOrText isKindOfClass:[NSEvent class]]){
+            if ([eventOrText isKindOfClass:[XVimKeyStroke class]]){
                 // Send the keyDown event directly to the view
-                [view keyDown:eventOrText];
+				NSEvent* event = [eventOrText toEvent];
+                [view keyDown:event];
             }else if([eventOrText isKindOfClass:[NSString class]]){
                 [view insertText:eventOrText];
             }

--- a/XVim/XVimRegisterEvaluator.m
+++ b/XVim/XVimRegisterEvaluator.m
@@ -9,6 +9,7 @@
 #import "XVimRegisterEvaluator.h"
 #import "XVimNormalEvaluator.h"
 #import "XVimRegister.h"
+#import "XVimKeyStroke.h"
 #import "XVim.h"
 #import "Logger.h"
 
@@ -26,8 +27,8 @@ XVimRegisterEvalMode _mode;
     return self;
 }
 
-- (XVimEvaluator*)eval:(NSEvent*) event ofXVim:(XVim*)xvim{
-    NSString* keyStr = [XVimEvaluator keyStringFromKeyEvent:event];
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim{
+    NSString* keyStr = [keyStroke toSelectorString];
     XVimRegister *xregister = [xvim findRegister:keyStr];
     if (_mode == REGISTER_EVAL_MODE_RECORD){
         if (xregister.isReadOnly == NO){
@@ -42,7 +43,7 @@ XVimRegisterEvalMode _mode;
     return nil;
 }
 
-- (XVimRegisterOperation)shouldRecordEvent:(NSEvent*) event inRegister:(XVimRegister*)xregister{
+- (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*)keyStroke inRegister:(XVimRegister*)xregister{
     return REGISTER_IGNORE;
 }
 

--- a/XVim/XVimSearchLineEvaluator.m
+++ b/XVim/XVimSearchLineEvaluator.m
@@ -10,14 +10,16 @@
 #import "XVimMotionEvaluator.h"
 #import "XVim.h"
 #import "Logger.h"
+#import "XVimKeyStroke.h"
 
 // Search Line 
 @implementation XVimSearchLineEvaluator
 @synthesize forward = _forward;
 @synthesize previous = _previous;
 
-- (XVimEvaluator*)eval:(NSEvent *)event ofXVim:(XVim *)xvim{
-    NSString *searchChar = [[event characters] substringWithRange:NSMakeRange(0, 1)];
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim *)xvim{
+	unichar key = keyStroke.key;
+    NSString *searchChar = [NSString stringWithCharacters:&key length:1];
     [xvim setSearchCharacter:searchChar backward:!self.forward previous:self.previous];
 
     NSTextView *view = (NSTextView*)[xvim superview];

--- a/XVim/XVimVisualEvaluator.m
+++ b/XVim/XVimVisualEvaluator.m
@@ -59,11 +59,16 @@
     return MODE_VISUAL;
 }
 
-- (XVimEvaluator*)eval:(NSEvent*)event ofXVim:(XVim*)xvim{
+- (XVimKeymap*)selectKeymap:(XVimKeymap**)keymaps
+{
+	return keymaps[MODE_VISUAL];
+}
+
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke ofXVim:(XVim*)xvim{
     DVTSourceTextView* v = [xvim sourceView];
     [v setSelectedRange:NSMakeRange(_insertion, 0)]; // temporarily cancel the current selection
     [v adjustCursorPosition];
-    XVimEvaluator *nextEvaluator = [super eval:event ofXVim:xvim];
+    XVimEvaluator *nextEvaluator = [super eval:keyStroke ofXVim:xvim];
     if (nextEvaluator == self){
         [self updateSelection];   
     }


### PR DESCRIPTION
- Read ~/.xvimrc on startup and execute each line as an ex command
- Implement map, nmap, imap, vmap, omap (only single -> multiple key)
- Pass XVimKeyStrokes around instead of NSEvents.
  An XVimKeyStroke is a combination of a unichar and the modifier flags.
  This is necessary for key mapping.
