### PR TITLE
Fix #113: Visual mode text objects.

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		C3AA7226152F186A00C61D97 /* XVimTildeEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = C3AA7225152F186A00C61D97 /* XVimTildeEvaluator.m */; };
 		C3AA722A152F1B1800C61D97 /* XVimLowercaseEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = C3AA7229152F1B1700C61D97 /* XVimLowercaseEvaluator.m */; };
 		C3AA722D152F1B2800C61D97 /* XVimUppercaseEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = C3AA722C152F1B2700C61D97 /* XVimUppercaseEvaluator.m */; };
+		C3EC83091534355600F84712 /* XVimSelectAction.m in Sources */ = {isa = PBXBuildFile; fileRef = C3EC83081534355600F84712 /* XVimSelectAction.m */; };
 		C3FA1A1D1532648700059BF6 /* XVimWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = C3FA1A1C1532648700059BF6 /* XVimWindow.m */; };
 		F100DC2E150BB6BC002C703C /* XVimRegisterEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = F100DC2D150BB6BC002C703C /* XVimRegisterEvaluator.m */; };
 		F17D013B150861DC00A8111B /* XVimRegister.m in Sources */ = {isa = PBXBuildFile; fileRef = F17D013A150861DC00A8111B /* XVimRegister.m */; };
@@ -119,6 +120,7 @@
 		A5118D9D14FF64F000C6AFB2 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Common.h; path = XVim/Common.h; sourceTree = "<group>"; };
 		A5118D9E14FF64F000C6AFB2 /* Common.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Common.m; path = XVim/Common.m; sourceTree = "<group>"; };
 		C32CE8621532F0E5002BCE2B /* XVimKeymapProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimKeymapProvider.h; path = XVim/XVimKeymapProvider.h; sourceTree = SOURCE_ROOT; };
+		C36266CB153455C9000C79D8 /* XVimMotionOption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimMotionOption.h; path = XVim/XVimMotionOption.h; sourceTree = SOURCE_ROOT; };
 		C366C23715287E080008C58E /* XVimMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimMode.h; path = XVim/XVimMode.h; sourceTree = SOURCE_ROOT; };
 		C366C23915287EE30008C58E /* XVimKeymap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimKeymap.h; path = XVim/XVimKeymap.h; sourceTree = SOURCE_ROOT; };
 		C366C23A15287EE30008C58E /* XVimKeymap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimKeymap.m; path = XVim/XVimKeymap.m; sourceTree = SOURCE_ROOT; };
@@ -151,6 +153,8 @@
 		C3AA722B152F1B2700C61D97 /* XVimUppercaseEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimUppercaseEvaluator.h; path = XVim/XVimUppercaseEvaluator.h; sourceTree = SOURCE_ROOT; };
 		C3AA722C152F1B2700C61D97 /* XVimUppercaseEvaluator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimUppercaseEvaluator.m; path = XVim/XVimUppercaseEvaluator.m; sourceTree = SOURCE_ROOT; };
 		C3AA7236153032F500C61D97 /* XVimPlaybackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimPlaybackHandler.h; path = XVim/XVimPlaybackHandler.h; sourceTree = SOURCE_ROOT; };
+		C3EC83071534355600F84712 /* XVimSelectAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimSelectAction.h; path = XVim/XVimSelectAction.h; sourceTree = SOURCE_ROOT; };
+		C3EC83081534355600F84712 /* XVimSelectAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimSelectAction.m; path = XVim/XVimSelectAction.m; sourceTree = SOURCE_ROOT; };
 		C3FA1A1B1532648700059BF6 /* XVimWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimWindow.h; path = XVim/XVimWindow.h; sourceTree = SOURCE_ROOT; };
 		C3FA1A1C1532648700059BF6 /* XVimWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimWindow.m; path = XVim/XVimWindow.m; sourceTree = SOURCE_ROOT; };
 		F100DC2C150BB6BC002C703C /* XVimRegisterEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimRegisterEvaluator.h; path = XVim/XVimRegisterEvaluator.h; sourceTree = SOURCE_ROOT; };
@@ -199,6 +203,8 @@
 				C36C1047153107CC00CE1D62 /* XVimOperatorAction.h */,
 				C36C104C153131C500CE1D62 /* XVimTextObjectEvaluator.h */,
 				C36C104D153131C500CE1D62 /* XVimTextObjectEvaluator.m */,
+				C3EC83071534355600F84712 /* XVimSelectAction.h */,
+				C3EC83081534355600F84712 /* XVimSelectAction.m */,
 			);
 			name = Operators;
 			sourceTree = "<group>";
@@ -267,6 +273,7 @@
 				C39DC81315326F5500185390 /* XVimCharacterSearch.h */,
 				C39DC81415326F5500185390 /* XVimCharacterSearch.m */,
 				C32CE8621532F0E5002BCE2B /* XVimKeymapProvider.h */,
+				C36266CB153455C9000C79D8 /* XVimMotionOption.h */,
 			);
 			name = XVim;
 			path = XVim_lite2;
@@ -451,6 +458,7 @@
 				C36C104E153131C600CE1D62 /* XVimTextObjectEvaluator.m in Sources */,
 				C3FA1A1D1532648700059BF6 /* XVimWindow.m in Sources */,
 				C39DC81515326F5500185390 /* XVimCharacterSearch.m in Sources */,
+				C3EC83091534355600F84712 /* XVimSelectAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XVim/NSTextView+VimMotion.h
+++ b/XVim/NSTextView+VimMotion.h
@@ -48,12 +48,7 @@
  *
  **/
 
-typedef enum{
-    MOTION_OPTION_NONE,
-    LEFT_RIGHT_WRAP,
-    LEFT_RIGHT_NOWRAP,
-    BIGWORD // for 'WORD' motion
-} MOTION_OPTION;
+#include "XVimMotionOption.h"
 
 typedef struct _XVimWordInfo{
     BOOL isFirstWordInALine;

--- a/XVim/XVimEvaluator.h
+++ b/XVim/XVimEvaluator.h
@@ -56,7 +56,7 @@ typedef enum {
 @interface XVimEvaluator : NSObject
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke inWindow:(XVimWindow*)window;
 - (XVimKeymap*)selectKeymapWithProvider:(id<XVimKeymapProvider>)keymapProvider;
-- (XVimEvaluator*)defaultNextEvaluatorWithXVim:(XVimWindow*)window;
+- (XVimEvaluator*)defaultNextEvaluatorInWindow:(XVimWindow*)window;
 - (NSUInteger)insertionPointInWindow:(XVimWindow*)window;
 
 - (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*)keyStroke inRegister:(XVimRegister*)xregister;

--- a/XVim/XVimEvaluator.m
+++ b/XVim/XVimEvaluator.m
@@ -34,7 +34,7 @@
 	}
     else{
         TRACE_LOG(@"SELECTOR %@ not found", NSStringFromSelector(handler));
-        return [self defaultNextEvaluatorWithXVim:window];
+        return [self defaultNextEvaluatorInWindow:window];
     }
 }
 
@@ -43,7 +43,7 @@
 	return [keymapProvider keymapForMode:MODE_GLOBAL_MAP];
 }
 
-- (XVimEvaluator*)defaultNextEvaluatorWithXVim:(XVimWindow*)window{
+- (XVimEvaluator*)defaultNextEvaluatorInWindow:(XVimWindow*)window{
     return nil;
 }
 

--- a/XVim/XVimMotionOption.h
+++ b/XVim/XVimMotionOption.h
@@ -1,0 +1,14 @@
+//
+//  XVimMotionOption.h
+//  XVim
+//
+//  Created by Tomas Lundell on 10/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+typedef enum{
+    MOTION_OPTION_NONE,
+    LEFT_RIGHT_WRAP,
+    LEFT_RIGHT_NOWRAP,
+    BIGWORD // for 'WORD' motion
+} MOTION_OPTION;

--- a/XVim/XVimOperatorEvaluator.m
+++ b/XVim/XVimOperatorEvaluator.m
@@ -44,12 +44,22 @@
 }
 
 - (XVimEvaluator*)a:(XVimWindow*)window {
-	XVimEvaluator* eval = [[XVimTextObjectEvaluator alloc] initWithOperatorAction:_operatorAction repeat:_repeat inclusive:YES];
+	XVimEvaluator* eval = [[XVimTextObjectEvaluator alloc] initWithOperatorAction:_operatorAction 
+																			 from:[window cursorLocation]
+																		   inMode:MODE_NORMAL
+																	   withParent:nil
+																		   repeat:_repeat 
+																		inclusive:YES];
 	return eval;
 }
 
 - (XVimEvaluator*)i:(XVimWindow*)window {
-	XVimEvaluator* eval = [[XVimTextObjectEvaluator alloc] initWithOperatorAction:_operatorAction repeat:_repeat inclusive:NO];
+	XVimEvaluator* eval = [[XVimTextObjectEvaluator alloc] initWithOperatorAction:_operatorAction 
+																			 from:[window cursorLocation]
+																		   inMode:MODE_NORMAL
+																	   withParent:nil
+																		   repeat:_repeat 
+																		inclusive:NO];
 	return eval;
 }
 

--- a/XVim/XVimSelectAction.h
+++ b/XVim/XVimSelectAction.h
@@ -1,0 +1,13 @@
+//
+//  XVimSelectAction.h
+//  XVim
+//
+//  Created by Tomas Lundell on 10/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "XVimOperatorAction.h"
+
+@interface XVimSelectAction : XVimOperatorAction
+
+@end

--- a/XVim/XVimSelectAction.m
+++ b/XVim/XVimSelectAction.m
@@ -1,0 +1,27 @@
+//
+//  XVimSelectAction.m
+//  XVim
+//
+//  Created by Tomas Lundell on 10/04/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "XVimSelectAction.h"
+#import "XVimVisualEvaluator.h"
+#import "XVimWindow.h"
+#import "DVTSourceTextView.h"
+#import "NSTextView+VimMotion.h"
+
+@implementation XVimSelectAction
+
+- (XVimEvaluator*)motionFixedFrom:(NSUInteger)from 
+							   To:(NSUInteger)to 
+							 Type:(MOTION_TYPE)type 
+						 inWindow:(XVimWindow*)window
+{
+	NSTextView *view = [window sourceView];
+	NSRange r = [view getOperationRangeFrom:from To:to Type:type];
+	return [[XVimVisualEvaluator alloc] initWithMode:MODE_CHARACTER withRange:r];
+}
+
+@end

--- a/XVim/XVimTextObjectEvaluator.h
+++ b/XVim/XVimTextObjectEvaluator.h
@@ -11,5 +11,10 @@
 @class XVimOperatorAction;
 
 @interface XVimTextObjectEvaluator : XVimEvaluator
-- (id)initWithOperatorAction:(XVimOperatorAction*)operatorAction repeat:(NSUInteger)repeat inclusive:(BOOL)inclusive;
+- (id)initWithOperatorAction:(XVimOperatorAction*)operatorAction 
+					from:(NSUInteger)location
+					  inMode:(XVIM_MODE)mode
+					withParent:(XVimEvaluator*)eval
+					  repeat:(NSUInteger)repeat 
+				   inclusive:(BOOL)inclusive;
 @end

--- a/XVim/XVimTextObjectEvaluator.m
+++ b/XVim/XVimTextObjectEvaluator.m
@@ -14,22 +14,46 @@
 
 @interface XVimTextObjectEvaluator() {
 	XVimOperatorAction *_operatorAction;
+	NSUInteger _location;
 	NSUInteger _repeat;
 	BOOL _inclusive;
+	XVIM_MODE _mode;
+	XVimEvaluator *_parent;
 }
 @end
 
 @implementation XVimTextObjectEvaluator
 
-- (id)initWithOperatorAction:(XVimOperatorAction*)operatorAction repeat:(NSUInteger)repeat inclusive:(BOOL)inclusive
+- (id)initWithOperatorAction:(XVimOperatorAction*)operatorAction 
+						from:(NSUInteger)location
+					  inMode:(XVIM_MODE)mode
+					withParent:(XVimEvaluator*)parent
+					  repeat:(NSUInteger)repeat 
+				   inclusive:(BOOL)inclusive
 {
 	if (self = [super init])
 	{
 		self->_operatorAction = operatorAction;
+		self->_location = location;
 		self->_repeat = repeat;
 		self->_inclusive = inclusive;
+		self->_mode = mode;
+		self->_parent = parent;
 	}
 	return self;
+}
+
+- (NSUInteger)insertionPointInWindow:(XVimWindow*)window
+{
+    return _location;
+}
+
+- (XVIM_MODE)becameHandlerInWindow:(XVimWindow*)window{
+	return _mode;
+}
+
+- (XVimEvaluator*)defaultNextEvaluatorInWindow:(XVimWindow*)window{
+    return _parent;
 }
 
 - (XVimEvaluator*)executeActionForRange:(NSRange)r inWindow:(XVimWindow*)window
@@ -39,36 +63,36 @@
 		[window.sourceView clampRangeToBuffer:&r];
 		return [_operatorAction motionFixedFrom:r.location To:r.location+r.length Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
 	}
-	return nil;
+	return _parent;
 }
 
 - (XVimEvaluator*)b:(XVimWindow*)window
 {
-	NSRange r = xv_current_block([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '(', ')');
+	NSRange r = xv_current_block([window.sourceView string], _location, _repeat, _inclusive, '(', ')');
 	return [self executeActionForRange:r inWindow:window];
 }
 
 - (XVimEvaluator*)B:(XVimWindow*)window
 {
-	NSRange r = xv_current_block([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '{', '}');
+	NSRange r = xv_current_block([window.sourceView string], _location, _repeat, _inclusive, '{', '}');
 	return [self executeActionForRange:r inWindow:window];
 }
 
 - (XVimEvaluator*)w:(XVimWindow*)window
 {
-	NSRange r = xv_current_word([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, NO);
+	NSRange r = xv_current_word([window.sourceView string], _location, _repeat, _inclusive, NO);
 	return [self executeActionForRange:r inWindow:window];
 }
 
 - (XVimEvaluator*)W:(XVimWindow*)window
 {
-	NSRange r = xv_current_word([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, YES);
+	NSRange r = xv_current_word([window.sourceView string], _location, _repeat, _inclusive, YES);
 	return [self executeActionForRange:r inWindow:window];
 }
 
 - (XVimEvaluator*)LSQUAREBRACKET:(XVimWindow*)window
 {
-	NSRange r = xv_current_block([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '[', ']');
+	NSRange r = xv_current_block([window.sourceView string], _location, _repeat, _inclusive, '[', ']');
 	return [self executeActionForRange:r inWindow:window];
 }
 
@@ -89,7 +113,7 @@
 
 - (XVimEvaluator*)LESSTHAN:(XVimWindow*)window
 {
-	NSRange r = xv_current_block([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '<', '>');
+	NSRange r = xv_current_block([window.sourceView string], _location, _repeat, _inclusive, '<', '>');
 	return [self executeActionForRange:r inWindow:window];
 }
 
@@ -110,13 +134,13 @@
 
 - (XVimEvaluator*)SQUOTE:(XVimWindow*)window
 {
-	NSRange r = xv_current_quote([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '\'');
+	NSRange r = xv_current_quote([window.sourceView string], _location, _repeat, _inclusive, '\'');
 	return [self executeActionForRange:r inWindow:window];
 }
 
 - (XVimEvaluator*)DQUOTE:(XVimWindow*)window
 {
-	NSRange r = xv_current_quote([window.sourceView string], [window.sourceView selectedRange].location, _repeat, _inclusive, '"');
+	NSRange r = xv_current_quote([window.sourceView string], _location, _repeat, _inclusive, '"');
 	return [self executeActionForRange:r inWindow:window];
 }
 

--- a/XVim/XVimVisualEvaluator.h
+++ b/XVim/XVimVisualEvaluator.h
@@ -24,6 +24,7 @@ typedef enum{
 }
 - (NSUInteger) insertionPointInWindow:(XVimWindow*)window;
 - (id)initWithMode:(VISUAL_MODE)mode;
-- (void)updateSelectionForXVim:(XVimWindow*)window;
+- (id)initWithMode:(VISUAL_MODE)mode withRange:(NSRange)range;
+- (void)updateSelectionInWindow:(XVimWindow*)window;
 - (XVimEvaluator*)ESC:(XVimWindow*)window;
 @end


### PR DESCRIPTION
Same commands supported as in normal mode.

The behaviour for w and W differs from Vim in that it just selects the
current word, where Vim will expand the current selection in these
cases.
