### PR TITLE
Issue #120: Preserve original key event.

### DIFF
--- a/XVim/XVimKeyStroke.h
+++ b/XVim/XVimKeyStroke.h
@@ -17,7 +17,7 @@
  * Returns all possible mapping options from an event
  * Eg. S-n would return S-n, S-N and N.
  * The primary key stroke is returned (in the above case, N is returned)
- * This is to be used in case a mapping is not found
+ * This is to be used in case a mapping is not found.
 **/
 + (XVimKeyStroke*)keyStrokeOptionsFromEvent:(NSEvent*)event into:(NSMutableArray*)options;
 
@@ -26,6 +26,14 @@
 
 // Parses a string into an array of key strokes
 + (void)fromString:(NSString *)string to:(NSMutableArray *)keystrokes;
+
+- (id)initWithKeyCode:(unichar)keyCode
+		modifierFlags:(int)modifierFlags;
+
+// Constructs a key stroke from an event
+- (id)initWithEvent:(NSEvent*)event 
+				keyCode:(unichar)keyCode 
+		  modifierFlags:(int)modifierFlags;
 
 // Generates an event from this key stroke
 - (NSEvent*)toEvent;


### PR DESCRIPTION
In case key strokes do not go through a key map, they come attached with
the original NSEvent. When toEvent is called and an NSEvent is attached,
just return that, otherwise (eg. from key maps) synthesise one.
