### PR TITLE
declare start_pos and end_pos as NSInteger

### DIFF
--- a/XVim/NSTextView+VimMotion.m
+++ b/XVim/NSTextView+VimMotion.m
@@ -1789,8 +1789,8 @@ NSRange xv_current_block(NSString *string, NSUInteger index, NSUInteger count, B
 		}
 	}
 	
-    int start_pos = (int)idx;
-    int end_pos   = (int)idx;
+    NSInteger start_pos = idx;
+    NSInteger end_pos   = idx;
     
     while (count-- > 0)
     {


### PR DESCRIPTION
Please consider merging this if it has no side effect. On one of my machine (Mountain Lion Preview 3 w/ Xcode 4.4 Preview 3) NSInteger is long, assigning xv_0() to int caused compiling error.
