### PR TITLE
fixes #209 - asterisk and number sign movement

### DIFF
--- a/XVim/XVimSearch.m
+++ b/XVim/XVimSearch.m
@@ -59,13 +59,11 @@
     searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\c" withString:@""];
     searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\C" withString:@""];
     
-    // In vim \< matches the start of a word and \> matches the end of a word.
+    // In vim \< matches the start of a word and \> matches the end of vims definition of a word.
     // Using NSRegularExpression with NSRegularExpressionUseUnicodeWordBoundaries
-    // \b matches word boundaries, but for some reason it does not properly handle : or .
-    // so add it to the search. This is not ideal but it mostly works. Please see
-    // the NSRegularExpression documentation for more info on this regular exrpression.
-    searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\<" withString:@"(:|\\.|\\b)"];
-    searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\>" withString:@"(:|\\.|\\b)"];
+    // \b matches word boundaries.
+    searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\<" withString:@"(\\b)"];
+    searchCmd = [searchCmd stringByReplacingOccurrencesOfString:@"\\>" withString:@"(\\b)"];
     
     // in vi, if there's no search string. use the last one specified. like you do for 'n'
     if( [searchCmd length] > 1 ){


### PR DESCRIPTION
fixes #209

Example: 
foo ::::foo_()_& foo45 ::::foo45_()_&

A cursor at the first occurrence of foo should go to the second one after pressing \* or #. 

The first occurrence of foo45 will only match with itself and the start of foo45 in ::::foo45_()_&
