### PR TITLE
Fixes #209 * and # search

### DIFF
--- a/XVim/XVimSearch.h
+++ b/XVim/XVimSearch.h
@@ -25,6 +25,9 @@ typedef enum {
 @property (strong) NSString* lastSearchCmd;
 @property (strong) NSString* lastSearchDisplayString;
 @property (strong) NSString* lastReplacementString;
+@property BOOL matchStart;
+@property BOOL matchEnd;
+
 
 - (NSRange)executeSearch:(NSString*)searchCmd display:(NSString*)displayString from:(NSUInteger)from inWindow:(XVimWindow*)window;
 - (NSRange)searchNextFrom:(NSUInteger)from inWindow:(XVimWindow*)window;


### PR DESCRIPTION
The current search for whole word includes the : and . positions that should not be included in the found location. This code culls out the improper search result bounds. 
