### PR TITLE
Added action on a paragraph in normal mode support.

### DIFF
--- a/XVim/XVimMotionOption.h
+++ b/XVim/XVimMotionOption.h
@@ -11,5 +11,6 @@ typedef enum{
     LEFT_RIGHT_WRAP = 0x01,
     LEFT_RIGHT_NOWRAP = 0x02,
     BIGWORD = 0x04, // for 'WORD' motion
-    INCLUSIVE = 0x08
+    INCLUSIVE = 0x08,
+    MOPT_PARA_BOUND_BLANKLINE = 0x10
 } MOTION_OPTION;

--- a/XVim/XVimSourceView+Vim.m
+++ b/XVim/XVimSourceView+Vim.m
@@ -915,7 +915,10 @@
  the macros ".IP", ".LP", etc.  (These are nroff macros, so the dot must be in
  the first column).  A section boundary is also a paragraph boundary.
  Note that a blank line (only containing white space) is NOT a paragraph
- boundary.
+ boundary. 
+ 
+ Note: if MOPT_PARA_BOUND_BLANKLINE is passed in then blank lines with whitespace are paragraph boundaries. This is to get propper function for the delete a paragraph command(dap).
+ 
  Also note that this does not include a '{' or '}' in the first column.  When
  the '{' flag is in 'cpoptions' then '{' in the first column is used as a
  paragraph boundary |posix|.
@@ -935,7 +938,16 @@
     for( ; pos < s.length && NSNotFound == paragraph_head ; pos++,prevpos++ ){
         unichar c = [s characterAtIndex:pos];
         unichar prevc = [s characterAtIndex:prevpos];
-        if( isNewLine(c) && isNewLine(prevc)){
+        if(isNewLine(prevc) && !isNewLine(c)){
+            if([self nextNonBlankInALine:pos] == NSNotFound && opt == MOPT_PARA_BOUND_BLANKLINE){
+                paragraph_found++;
+                if(count == paragraph_found){
+                    paragraph_head = pos;
+                    break;
+                }
+            }
+        }
+        if( (isNewLine(c) && isNewLine(prevc)) ){
             if( newlines_skipped ){
                 paragraph_found++;
                 if( count  == paragraph_found ){

--- a/XVim/XVimTextObjectEvaluator.m
+++ b/XVim/XVimTextObjectEvaluator.m
@@ -98,6 +98,23 @@
 	return [self executeActionForRange:r inWindow:window];
 }
 
+-(XVimEvaluator*)p:(XVimWindow*)window
+{
+    NSUInteger start = [self insertionPointInWindow:window];
+    if(start != 0){
+        start = [window.sourceView paragraphsBackward:[self insertionPointInWindow:window] count:1 option:MOPT_PARA_BOUND_BLANKLINE];
+    }
+    NSUInteger starts_end = [window.sourceView paragraphsForward:start count:1 option:MOPT_PARA_BOUND_BLANKLINE];
+    NSUInteger end = [window.sourceView paragraphsForward:[self insertionPointInWindow:window] count:[self numericArg] option:MOPT_PARA_BOUND_BLANKLINE];
+    
+    if(starts_end != end){
+        start = starts_end;
+    }
+    
+    NSRange r = NSMakeRange(start, end - start);
+	return [self executeActionForRange:r inWindow:window];
+}
+
 - (XVimEvaluator*)w:(XVimWindow*)window
 {
     MOTION_OPTION opt = _inclusive ? INCLUSIVE : MOTION_OPTION_NONE;


### PR DESCRIPTION
Modified the way to check for paragraphs when issuing this command to stop at blank lines that are only whitespace. This is to conform to the exception that vim makes with the definition of paragraphs. 

visual mode does not advance to the next paragraph when issuing multiple ap commands though.

fixes #235 for normal mode but in visual mode only can select one paragraph.
