### PR TITLE
Draw the cursor in XVimCommandField

### DIFF
--- a/XVim/XVimCommandField.m
+++ b/XVim/XVimCommandField.m
@@ -50,6 +50,7 @@
 // Drawing Caret
 - (void)drawInsertionPointInRect:(NSRect)rect color:(NSColor*)color turnedOn:(BOOL)flag
 {
+    if(flag) {
         color = [color colorWithAlphaComponent:0.5];
         NSPoint aPoint=NSMakePoint( rect.origin.x,rect.origin.y+rect.size.height/2);
         NSUInteger glyphIndex = [[self layoutManager] glyphIndexForPoint:aPoint inTextContainer:[self textContainer]];
@@ -61,10 +62,9 @@
             rect.size.width=glyphRect.size.width;
         
         NSRectFillUsingOperation( rect, NSCompositeSourceOver);
-}
-
-- (void)updateInsertionPointStateAndRestartTimer:(BOOL)restartFlag{
-    
+    } else {
+        [self setNeedsDisplayInRect:self.visibleRect avoidAdditionalLayout:NO];
+    }
 }
 
 - (void)hide


### PR DESCRIPTION
An empty implementation of updateInsertionPointStateAndRestartTimer: prevented XVimCommandField from drawing the cursor. When editing longer search and replace commands this caused difficulties for me.

Removed this implementation, and updated the drawInsertionPointInRect:turnedOn: method to pay attention to the turnedOn flag option.
