### PR TITLE
Allow key mapping with space in arguments

### DIFF
--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -938,11 +938,13 @@
 		
 		[subStrings addObject:string];
 	}
-		
-	if (subStrings.count == 2)
+  
+	if (subStrings.count >= 2)
 	{
 		NSString *fromString = [subStrings objectAtIndex:0];
-		NSString *toString = [subStrings objectAtIndex:1];
+    
+    [subStrings removeObjectAtIndex:0];
+		NSString *toString = [subStrings componentsJoinedByString:@" "]; // get all args seperate by space
 		
 		NSMutableArray *fromKeyStrokes = [[NSMutableArray alloc] init];
 		[XVimKeyStroke fromString:fromString to:fromKeyStrokes];

--- a/XVim/XVimKeyStroke.m
+++ b/XVim/XVimKeyStroke.m
@@ -337,8 +337,8 @@ static NSMutableDictionary *s_stringToKeyCode = NULL;
 		map(@"RIGHT", 63235);
 		map(@"FORWARD_DELETE", 63272);
 		
-		// Between space and del (non-inclusive), add ascii names
-		for (int i = 33; i < 127; ++i)
+		// From space to del (non-inclusive), add ascii names
+		for (int i = 32; i < 127; ++i)
 		{
 			unichar c = i;
 			NSString *string = [NSString stringWithCharacters:&c length:1];


### PR DESCRIPTION
This will allow user to do mappings like

```
nmap ,m :xccmd showDocumentItemsMenu<cr>
```

I've tried to test everything the best I can, and it seems to work fine even if space is mapped as a keystroke.
