### PR TITLE
Fix declaration after use in XVimInsertEvaluator

### DIFF
--- a/XVim/XVimInsertEvaluator.m
+++ b/XVim/XVimInsertEvaluator.m
@@ -199,6 +199,12 @@
 	[[window sourceView] adjustCursorPosition];
 }
 
+- (BOOL)windowShouldReceive:(SEL)keySelector {
+  BOOL b = YES ^ ([NSStringFromSelector(keySelector) isEqualToString:@"C_e:"] ||
+                  [NSStringFromSelector(keySelector) isEqualToString:@"C_y:"]);
+  return b;
+}
+
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke inWindow:(XVimWindow*)window{
     XVimEvaluator *nextEvaluator = self;
     SEL keySelector = [keyStroke selectorForInstance:self];
@@ -233,12 +239,6 @@
     return nextEvaluator;
 }
 
-- (BOOL)windowShouldReceive:(SEL)keySelector {
-    BOOL b = YES ^ ([NSStringFromSelector(keySelector) isEqualToString:@"C_e:"] ||
-                    [NSStringFromSelector(keySelector) isEqualToString:@"C_y:"]);
-    return b;
-}
-
 - (XVimEvaluator*)ESC:(XVimWindow*)window{
     return nil;
 }
@@ -271,6 +271,24 @@
     return self;
 }
 
+- (void)C_yC_eHelper:(XVimWindow *)window forC_y:(BOOL)handlingC_y {
+  NSUInteger currentCursorIndex = [[window sourceView] selectedRange].location;
+  NSUInteger currentColumnIndex = [[window sourceView] columnNumber:currentCursorIndex];
+  NSUInteger newCharIndex;
+  if (handlingC_y) {
+    newCharIndex = [[window sourceView] prevLine:currentCursorIndex column:currentColumnIndex count:[self numericArg] option:MOTION_OPTION_NONE];
+  } else {
+    newCharIndex = [[window sourceView] nextLine:currentCursorIndex column:currentColumnIndex count:[self numericArg] option:MOTION_OPTION_NONE];
+  }
+  NSUInteger newColumnIndex = [[window sourceView] columnNumber:newCharIndex];
+  NSLog(@"Old column: %ld\tNew column: %ld", currentColumnIndex, newColumnIndex);
+  if (currentColumnIndex == newColumnIndex) {
+    unichar u = [[[window sourceView] string] characterAtIndex:newCharIndex];
+    NSString *charToInsert = [NSString stringWithFormat:@"%c", u];
+    [[window sourceView] insertText:charToInsert];
+  }
+}
+
 - (XVimEvaluator*)C_y:(XVimWindow*)window{
     [self C_yC_eHelper:window forC_y:YES];
     return self;
@@ -290,24 +308,6 @@
     [action motionFixedFrom:from To:to Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
     
     return self;
-}
-    
-- (void)C_yC_eHelper:(XVimWindow *)window forC_y:(BOOL)handlingC_y {
-    NSUInteger currentCursorIndex = [[window sourceView] selectedRange].location;
-    NSUInteger currentColumnIndex = [[window sourceView] columnNumber:currentCursorIndex];
-    NSUInteger newCharIndex;
-    if (handlingC_y) {
-        newCharIndex = [[window sourceView] prevLine:currentCursorIndex column:currentColumnIndex count:[self numericArg] option:MOTION_OPTION_NONE];
-    } else {
-        newCharIndex = [[window sourceView] nextLine:currentCursorIndex column:currentColumnIndex count:[self numericArg] option:MOTION_OPTION_NONE];
-    }
-    NSUInteger newColumnIndex = [[window sourceView] columnNumber:newCharIndex];
-    NSLog(@"Old column: %ld\tNew column: %ld", currentColumnIndex, newColumnIndex);
-    if (currentColumnIndex == newColumnIndex) {
-        unichar u = [[[window sourceView] string] characterAtIndex:newCharIndex];
-        NSString *charToInsert = [NSString stringWithFormat:@"%c", u];
-        [[window sourceView] insertText:charToInsert];
-    }
 }
 
 - (XVimRegisterOperation)shouldRecordEvent:(XVimKeyStroke*)keyStroke inRegister:(XVimRegister*)xregister{


### PR DESCRIPTION
Following from 223a8e7d9fb and edec6506114, helper methods were declared before use, and this broke the build out of the box for me on Snow Leopard.
