### PR TITLE
implement laststatus option

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -139,6 +139,7 @@ The dot command ('.') is supported.
   [no]smartcase |
   guioptions | See below
   timeoutlen | The time in milliseconds that is waited for mapped key sequence to complete (default 1000)
+  laststatus | 0 or 1 : status line is hidden, 2 : status line is displayed  (default 2)
 
 ## guioptions
 

--- a/XVim/XVimOptions.h
+++ b/XVim/XVimOptions.h
@@ -18,6 +18,7 @@
 @property BOOL debug;
 @property (copy) NSString *guioptions;
 @property (copy) NSString *timeoutlen;
+@property int laststatus;
 
 - (id)getOption:(NSString*)name;
 - (void)setOption:(NSString*)name value:(id)value;

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -24,6 +24,7 @@
 @synthesize guioptions = _guioptions;
 @synthesize debug = _debug;
 @synthesize timeoutlen = _timeoutlen;
+@synthesize laststatus = _laststatus;
 
 - (id)init{
     if( self = [super init] ){
@@ -37,6 +38,7 @@
          @"gdefault",@"gd",
          @"smartcase",@"scs",
          @"timeoutlen",@"tm",
+         @"laststatus",@"ls",
          nil];
         
         // Default values
@@ -48,6 +50,7 @@
 		_smartcase = NO;
 		_guioptions = @"rb";
         _timeoutlen = @"1000";
+        _laststatus = 2;
     }
     return self;
 }

--- a/XVim/XVimStatusLine.m
+++ b/XVim/XVimStatusLine.m
@@ -12,6 +12,8 @@
 #import "Logger.h"
 #import "NSInsetTextView.h"
 #import <objc/runtime.h>
+#import "XVim.h"
+#import "XVimOptions.h"
 
 #define STATUS_LINE_HEIGHT 18 
 
@@ -55,10 +57,17 @@
 	CGFloat verticalInset = MAX((STATUS_LINE_HEIGHT - [sourceFont pointSize]) / 2, 0);
 	CGSize inset = CGSizeMake(horizontalInset, verticalInset);
 	
-    NSRect parent = [container frame];
-    [self setFrame:NSMakeRect(0, 0, parent.size.width, STATUS_LINE_HEIGHT)];
-    [_background setFrame:NSMakeRect(0, 0, parent.size.width, STATUS_LINE_HEIGHT)];
-    [_status setFrame:NSMakeRect(0, 0, parent.size.width, STATUS_LINE_HEIGHT)];
+    XVimOptions* options = [[XVim instance] options];
+    CGFloat height;
+    if( options.laststatus == 2 ){
+        height = STATUS_LINE_HEIGHT;
+    } else {
+        height = 0;
+    }
+    NSRect parentRect = [container frame];
+    [self setFrame:NSMakeRect(0, 0, parentRect.size.width, height)];
+    [_background setFrame:NSMakeRect(0, 0, parentRect.size.width, STATUS_LINE_HEIGHT)];
+    [_status setFrame:NSMakeRect(0, 0, parentRect.size.width, STATUS_LINE_HEIGHT)];
 	[_status setFont:sourceFont];
 	[_status setInset:inset];
     // This is heuristic way...
@@ -66,7 +75,7 @@
         // Nothing ( Maybe AutoLayout view does the job "automatically")
     }else{
         if( [container subviews].count > 0 ){
-            [[[container subviews] objectAtIndex:0] setFrame:NSMakeRect(0, STATUS_LINE_HEIGHT, parent.size.width, parent.size.height-STATUS_LINE_HEIGHT)];
+            [[[container subviews] objectAtIndex:0] setFrame:NSMakeRect(0, height, parentRect.size.width, parentRect.size.height-height)];
         }
     }
 }


### PR DESCRIPTION
As laststatus=0 is set in .xvimrc, status line is hidden.
The default value is 2 so that it is similarly displayed as former.
laststatus=1 is equivalent to laststatus=0 in XVim now.
