### PR TITLE
Fix cursor position after cb, cB

### DIFF
--- a/XVim/XVimDeleteEvaluator.m
+++ b/XVim/XVimDeleteEvaluator.m
@@ -36,6 +36,29 @@
 	return self;
 }
 
+- (XVimEvaluator*)b:(XVimWindow*)window{
+    if( _insertModeAtCompletion ){
+        // cb is special case of word motion
+        NSUInteger to = [[window sourceView] selectedRange].location;
+        NSUInteger from = [[window sourceView] wordsBackward:to count:[self numericArg] option:MOTION_OPTION_NONE];
+        return [self _motionFixedFrom:from To:to Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
+    }else{
+        return [super b:window];
+    }
+}
+
+- (XVimEvaluator*)B:(XVimWindow*)window{
+    if( _insertModeAtCompletion ){
+        // cB is special case of word motion
+        NSUInteger to = [[window sourceView] selectedRange].location;
+        NSUInteger from = [[window sourceView] wordsBackward:to count:[self numericArg] option:BIGWORD];
+        return [self _motionFixedFrom:from To:to Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
+    }else{
+        return [super B:window];
+    }
+}
+
+
 - (XVimEvaluator*)c:(XVimWindow*)window
 {
     if( !_insertModeAtCompletion ){

--- a/XVim/XVimNormalEvaluator.m
+++ b/XVim/XVimNormalEvaluator.m
@@ -522,7 +522,7 @@
 	// Xcode crashes if we cut a zero length selection
 	if (replacementRange.length > 0)
 	{
-		[view cutText]; // Can't use del here since we may want to wind up at end of line
+		[view deleteText]; // Can't use del here since we may want to wind up at end of line
 	}
 	
     return [[XVimInsertEvaluator alloc] initWithContext:[[XVimEvaluatorContext alloc] init]

--- a/XVim/XVimOperatorEvaluator.h
+++ b/XVim/XVimOperatorEvaluator.h
@@ -20,6 +20,8 @@
 	   operatorAction:(XVimOperatorAction*)action 
 		   withParent:(XVimEvaluator*)parent;
 
+- (XVimEvaluator*)b:(XVimWindow*)window;
+- (XVimEvaluator*)B:(XVimWindow*)window;
 - (XVimEvaluator*)w:(XVimWindow*)window;
 - (XVimEvaluator*)W:(XVimWindow*)window;
 @end

--- a/XVim/XVimOperatorEvaluator.m
+++ b/XVim/XVimOperatorEvaluator.m
@@ -83,6 +83,19 @@
 	return eval;
 }
 
+- (XVimEvaluator*)b:(XVimWindow*)window{
+    NSUInteger from = [[window sourceView] selectedRange].location;
+    NSUInteger to = [[window sourceView] wordsBackward:from count:[self numericArg] option:MOTION_OPTION_NONE];
+    return [self _motionFixedFrom:from To:to Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
+}
+
+- (XVimEvaluator*)B:(XVimWindow*)window{
+    NSUInteger from = [[window sourceView] selectedRange].location;
+    NSUInteger to = [[window sourceView] wordsBackward:from count:[self numericArg] option:BIGWORD];
+    return [self _motionFixedFrom:from To:to Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
+}
+
+
 - (XVimEvaluator*)i:(XVimWindow*)window {
 	XVimEvaluator* eval = [[XVimTextObjectEvaluator alloc] initWithContext:[[self contextCopy] appendArgument:@"i"]
 															operatorAction:_operatorAction 


### PR DESCRIPTION
The b and B modifiers do not appear to work as well as their counterparts w and W. Doing cb or db will delete to the beginning of the word, but the cursor will not move accordingly, which makes cb rather difficult to use.

This pull request adds support for `b` and `B` modifiers, based on existing code for `w` and `W`.
