### PR TITLE
Support for Y in visual mode, indent fixes

### DIFF
--- a/XVim/XVimVisualEvaluator.m
+++ b/XVim/XVimVisualEvaluator.m
@@ -301,12 +301,14 @@ static NSString* MODE_STRINGS[] = {@"-- VISUAL --", @"-- VISUAL LINE --", @"-- V
     NSUInteger loc = [view selectedRange].location;
     NSString *text = [[XVim instance] pasteText:[self yankRegister]];
     if (text.length > 0){
-        unichar uc = [text characterAtIndex:[text length] -1];
-        if ([[NSCharacterSet newlineCharacterSet] characterIsMember:uc]) {
-            if( [view isBlankLine:loc] && ![view isEOF:loc]){
-                [view setSelectedRange:NSMakeRange(loc+1,0)];
-            }else{
-                [view insertNewline];
+        if (_mode == MODE_CHARACTER) {
+            unichar uc = [text characterAtIndex:[text length] -1];
+            if ([[NSCharacterSet newlineCharacterSet] characterIsMember:uc]) {
+                if( [view isBlankLine:loc] && ![view isEOF:loc]){
+                    [view setSelectedRange:NSMakeRange(loc+1,0)];
+                }else{
+                    [view insertNewline];
+                }
             }
         }
         


### PR DESCRIPTION
This pull contains 2 commits, for separate issues in visual mode:
- The second commit adds support for Y in visual mode, [Issue 317](https://github.com/JugglerShu/XVim/issues/317)
- The earlier commit removes logic that was adding extra newlines when putting (`p`) in visual mode. I'm not sure why this code was added, but the extra newlines were triggering Xcode's autoindent behavior and causing formatting problems. Removing this code fixed those issues.
