### PR TITLE
Adds underscore motion command

### DIFF
--- a/XVim/XVimMotionEvaluator.m
+++ b/XVim/XVimMotionEvaluator.m
@@ -416,6 +416,24 @@
     return [self _motionFixedFrom:r.location To:head Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
 }
 
+// Underscore ( "_") moves the cursor to the start of the line (past leading whitespace)
+// Note: underscore without any numeric arguments behaves like caret but with a numeric argument greater than 1
+// it will moves to start of the numeric argument - 1 lines down.
+- (XVimEvaluator*)UNDERSCORE:(XVimWindow*)window{
+    XVimSourceView* view = [window sourceView];
+    NSRange r = [view selectedRange];
+    NSUInteger repeat = [[self context] numericArg];
+    NSUInteger linesUpCursorloc = [view nextLine:r.location column:0 count:(repeat - 1) option:MOTION_OPTION_NONE];
+    NSUInteger head = [view headOfLineWithoutSpaces:linesUpCursorloc];
+    if( NSNotFound == head && linesUpCursorloc != NSNotFound){
+        head = linesUpCursorloc;
+    }else if(NSNotFound == head){
+        head = r.location;
+    }
+    return [self _motionFixedFrom:r.location To:head Type:CHARACTERWISE_EXCLUSIVE inWindow:window];
+}
+
+
 - (XVimEvaluator*)DOLLAR:(XVimWindow*)window{
     NSRange begin = [[window sourceView] selectedRange];
     NSUInteger end = [[window sourceView] endOfLine:begin.location];


### PR DESCRIPTION
Acts like ^ (first non blank in a line) but with numeric arguments greater than 1 it will go down (numeric argument - 1) lines and position the cursor on the first non blank of that line. Otherwise it just goes to the first non blank in a line.

fixes bug #320 
