### PR TITLE
Logging keyDown events through DEBUG_LOG macro

### DIFF
--- a/XVim/DVTSourceTextViewHook.m
+++ b/XVim/DVTSourceTextViewHook.m
@@ -97,7 +97,7 @@
     }
    
     unichar charcode = [theEvent unmodifiedKeyCode];
-    [Logger logWithLevel:LogDebug format:@"Obj:%p keyDown : keyCode:%d characters:%@ charsIgnoreMod:%@ cASCII:%d", self,[theEvent keyCode], [theEvent characters], [theEvent charactersIgnoringModifiers], charcode];
+    DEBUG_LOG(@"Obj:%p keyDown : keyCode:%d characters:%@ charsIgnoreMod:%@ cASCII:%d", self,[theEvent keyCode], [theEvent characters], [theEvent charactersIgnoringModifiers], charcode);
     
     if( [window handleKeyEvent:theEvent] ){
         return;


### PR DESCRIPTION
A very simple change, I found annoying that even building with -DLOGGER_DISABLE_DEBUG my console would get flooded with keyDown events logs, and this might probably be a call that was skipped during the process of wrapping logs and traces in macros.
