### PR TITLE
Use a cast to unsigned int instead of a string method

### DIFF
--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -624,7 +624,7 @@
                 parsing++;
                 count++;
             }
-            addr = [[NSString stringWithCharacters:tmp length:count] unsignedIntValue];
+            addr = (unsigned int)[[NSString stringWithCharacters:tmp length:count] intValue];
             if( 0 == addr ){
                 addr = NSNotFound;
             }
@@ -666,7 +666,7 @@
                 parsing++;
                 count++;
             }
-            n = [[NSString stringWithCharacters:tmp length:count] unsignedIntValue];
+            n = (unsigned int)[[NSString stringWithCharacters:tmp length:count] intValue];
         }
         
         // Calc the address from base


### PR DESCRIPTION
There isn't an official method to get `unsignedIntValue`. This will use a cast on `intValue` instead.
