### PR TITLE
Fix crash typing '100' in Xcode5

### DIFF
--- a/XVim/XVimEvaluatorContext.m
+++ b/XVim/XVimEvaluatorContext.m
@@ -71,12 +71,14 @@
 - (void)pushEmptyNumericArgHead
 {
 	_numericArgTail = [self numericArg];
+    [_numericArgHead release];
 	_numericArgHead = nil;
 }
 
 - (void)setNumericArgHead:(NSUInteger)numericArg
 {
-	_numericArgHead = [NSNumber numberWithUnsignedInteger:numericArg];
+    [_numericArgHead release];
+	_numericArgHead = [[NSNumber numberWithUnsignedInteger:numericArg] retain];
 }
 
 - (NSNumber*)numericArgHead
@@ -91,13 +93,16 @@
 
 - (XVimEvaluatorContext*)setArgumentString:(NSString*)argument
 {
+    [_argumentString release];
 	_argumentString = [argument copy];
 	return self;
 }
 
 - (XVimEvaluatorContext*)appendArgument:(NSString*)argument
 {
-	_argumentString = [[_argumentString copy] stringByAppendingString:argument];
+    NSString* str = [_argumentString stringByAppendingString:argument];
+    [_argumentString release];
+    _argumentString = [str retain];
 	return self;
 }
 


### PR DESCRIPTION
relating #402 issue.
It may be a bug of Xcode5, but this patch has no problem in Xcode 4.6.3 too.
