### PR TITLE
Exit visual mode when cutting text in the editor

### DIFF
--- a/XVim/DVTSourceTextViewHook.h
+++ b/XVim/DVTSourceTextViewHook.h
@@ -24,6 +24,7 @@
 - (void)mouseDown_:(NSEvent *)theEvent;
 - (void)mouseUp_:(NSEvent *)theEvent;
 - (void)mouseDragged_:(NSEvent *)theEvent;
+- (void)cut_:(id)sender;
 - (void)drawRect_:(NSRect)dirtyRect;
 - (BOOL) performKeyEquivalent_:(NSEvent *)theEvent;
 - (BOOL)shouldDrawInsertionPoint_;

--- a/XVim/DVTSourceTextViewHook.m
+++ b/XVim/DVTSourceTextViewHook.m
@@ -43,6 +43,7 @@
     [self hook:@"keyDown:"];
     [self hook:@"mouseDown:"];
     [self hook:@"mouseDragged:"];
+    [self hook:@"cut:"];
     [self hook:@"drawRect:"];
     [self hook:@"performKeyEquivalent:"];
     [self hook:@"shouldDrawInsertionPoint"];
@@ -61,6 +62,7 @@
     [self unhook:@"keyDown:"];
     [self unhook:@"mouseDown:"];
     [self unhook:@"mouseDragged:"];
+    [self unhook:@"cut:"];
     [self unhook:@"drawRect:"];
     [self unhook:@"performKeyEquivalent:"];
     [self unhook:@"shouldDrawInsertionPoint"];
@@ -135,6 +137,14 @@
 	DVTSourceTextView *base = (DVTSourceTextView*)self;
     [base mouseDragged_:theEvent];
     return;
+}
+
+- (void)cut:(id)sender
+{
+    DVTSourceTextView *base = (DVTSourceTextView*)self;
+    [base cut_:sender];
+    
+    [[XVimWindow associateOf:base] setEvaluator:nil];
 }
 
 - (void)drawRect:(NSRect)dirtyRect{


### PR DESCRIPTION
Fixes a crash when cutting text at the end of a file. Also ensures the cursor goes to the right spot after cutting.
