### PR TITLE
Fixed cmd+click, option+click.

### DIFF
--- a/XVim/DVTSourceTextViewHook.m
+++ b/XVim/DVTSourceTextViewHook.m
@@ -138,6 +138,13 @@
     @try{
         TRACE_LOG(@"Event:%@", theEvent.description);
         DVTSourceTextView *base = (DVTSourceTextView*)self;
+        if (theEvent.modifierFlags & NSCommandKeyMask ||
+            theEvent.modifierFlags & NSAlternateKeyMask)
+        {
+            [base mouseDown_:theEvent];
+            return;
+        }
+
         XVimWindow* window = [base xvimWindow];
         [window mouseDown:theEvent];
     }@catch (NSException* exception) {


### PR DESCRIPTION
The hooks of mouseDown: would disable cmd+click & option+click. This patch can simply fix it.
