### PR TITLE
Develop

### DIFF
--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -1233,7 +1233,7 @@
 //Title:Show Object Library    Action:showLibraryWithChoiceFromSender:
 //Title:Show Media Library    Action:showLibraryWithChoiceFromSender:
 //        [NSApp sendAction:item.action to:item.target from:self];
-          [NSApp sendAction:item.action to:item.target from:nil];
+          [NSApp sendAction:item.action to:item.target from:item];
     }
 }
 


### PR DESCRIPTION
with -menucmd:inWindow, I don't need to check menu action again, just take a look at menu title.
 -xctabctrl:inWindow, may be not useful. and it is just part of xccmd, and not work well.
