### PR TITLE
when cursor moves because of C_a/C_x column should be forgotten

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -970,7 +970,7 @@
     }
 
     [self insertText:repl replacementRange:range];
-    self.insertionPoint = range.location + repl.length - 1;
+    [self xvim_moveCursor:range.location + repl.length - 1 preserveColumn:NO];
 }
 
 - (void)xvim_sortLinesFrom:(NSUInteger)line1 to:(NSUInteger)line2 withOptions:(XVimSortOptions)options{

--- a/XVim/Test/XVimTester+Operator.m
+++ b/XVim/Test/XVimTester+Operator.m
@@ -532,6 +532,7 @@
             XVimMakeTestCase(@"10JK",   2, 0, @"<C-a>", @"10JK",   2, 0),
             XVimMakeTestCase(@"017JK",  0, 0, @"<C-a>", @"020JK",  2, 0),
             XVimMakeTestCase(@"0x19JK", 0, 0, @"<C-a>", @"0x1aJK", 3, 0),
+            XVimMakeTestCase(@" 10JK\n01234",  0, 0, @"<C-a>j", @" 11JK\n01234",  8, 0),
 
             // Insert and Ctrl-e
             //   The following test case sometimes fails. I do not know when it occurs but occasionally it happens.


### PR DESCRIPTION
Add a test-case about that
