### PR TITLE
Use number option when using relativenumber option

### DIFF
--- a/XVim/DVTTextSidebarViewHook.m
+++ b/XVim/DVTTextSidebarViewHook.m
@@ -93,6 +93,7 @@ static CGFloat kTextSideBarLineNumberRightPadding = 5.0;
     DVTSourceTextView *sourceTextView = [DVTTextSidebarViewHook sourceTextViewForTextSideBarView:textSidebarView];
     long long currentLineNumber = [sourceTextView _currentLineNumber];
     long long relativeLineNumber = llabs(((long long)lineNumber - currentLineNumber));
+    if (XVim.instance.options.number && relativeLineNumber == 0) relativeLineNumber = lineNumber;
     NSString *relativeLineNumberString = [@(relativeLineNumber) stringValue];
     
     NSDictionary *attributes = @{NSForegroundColorAttributeName: [textSidebarView lineNumberTextColor],


### PR DESCRIPTION
Allow the number option to keep the current line set to the actual line number when using the relativenumber option.
