### PR TITLE
Fix crash while navigating up/down in the stack frame

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -607,8 +607,10 @@
         if( currentRange.location != prevPlaceHolder.location && currentRange.location == (prevPlaceHolder.location + prevPlaceHolder.length) ){
             //The condition here means that just before current insertion point is a placeholder.
             //So we select the the place holder and its already selected by "selectedPreviousPlaceholder" above
-        }else{
-            [self setSelectedRange:NSMakeRange(currentRange.location-1, 0)];
+        } else{
+            if ([[self string] length] > currentRange.location) {
+                [self setSelectedRange:NSMakeRange(currentRange.location-1, 0)];
+            }
         }
     }
     return;


### PR DESCRIPTION
Here is the crash report:

Crashed Thread:  0  Dispatch queue: com.apple.main-thread

Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000

Application Specific Information:
ProductBuildVersion: 5B1008
ASSERTION FAILURE in /SourceCache/DVTFrameworks/DVTFrameworks-5074/DVTKit/TextCompletion/DVTCompletingTextView.m:1337
Details:  Attempt to select an invalid range of text: {18446744073709551615, 0}. Text length: 0. (Please file a Radar. OK to Continue from here.)
Object:   <DVTSourceTextView: 0x7fbb55bd3440>
Method:   -setSelectedRange:
Thread:   <NSThread: 0x7fbb4ac15b50>{name = (null), num = 1}
Hints:   None
Backtrace:
  0  0x00000001064a8a35 -[IDEAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:](in IDEKit)
  1  0x00000001052c3519 _DVTAssertionHandler (in DVTFoundation)
  2  0x00000001052c37ff _DVTAssertionFailureHandler (in DVTFoundation)
  3  0x000000010570963d -[DVTCompletingTextView setSelectedRange:](in DVTKit)
  4  0x00000001057330f4 -[DVTSourceTextView setSelectedRange:](in DVTKit)
  5  0x00007fff83a2815b _NSSetRangeValueAndNotify (in Foundation)
  6  0x000000011193d051 -[NSTextView(VimOperation) xvim_adjustCursorPosition] at /Users/mohitsharma/projects/XVim/XVim/NSTextView+VimOperation.m:601 (in XVim)
  7  0x0000000111905171 -[XVimWindow syncEvaluatorStack] at /Users/mohitsharma/projects/XVim/XVim/XVimWindow.m:290 (in XVim)
  8  0x0000000111903ffa -[XVimWindow _documentChangedNotification:] at /Users/mohitsharma/projects/XVim/XVim/XVimWindow.m:119 (in XVim)
  9  0x00007fff882fbe0c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ (in CoreFoundation)
 10  0x00007fff881efa6d _CFXNotificationPost (in CoreFoundation)
 11  0x00007fff8390b7ba -[NSNotificationCenter postNotificationName:object:userInfo:](in Foundation)
 12  0x00000001118cd2fe -[XVim observeValueForKeyPath:ofObject:change:context:] at /Users/mohitsharma/projects/XVim/XVim/XVim.m:233 (in XVim)
 13  0x00007fff83911f28 NSKeyValueNotifyObserver (in Foundation)
 14  0x00007fff839329c7 -[NSObject(NSKeyValueObserverRegistration) _addObserver:forProperty:options:context:](in Foundation)
 15  0x00007fff839326f7 -[NSObject(NSKeyValueObserverRegistration) addObserver:forKeyPath:options:context:](in Foundation)
 16  0x000000011190a49d -[IDEEditorHook didSetupEditor] at /Users/mohitsharma/projects/XVim/XVim/IDEEditorHook.m:28 (in XVim)
 17  0x000000010b5e0324 -[IDESourceCodeEditor didSetupEditor](in IDESourceEditor)
 18  0x0000000106454c1e -[IDEEditorContext _notifyDelegateAndOpenNavigableItem:withContentsURL:documentExtensionIdentifier:locationToSelect:annotationRepresentedObject:stateDictionary:annotationWantsIndicatorAnimation:exploreAnnotationRepresentedObject:highlightSelection:skipSubDocumentNavigationUnlessEditorIsReplaced:](in IDEKit)
 19  0x0000000106327097 -[IDEEditorContext _notifyDelegateAndOpenEditorOpenSpecifier:updateHistory:](in IDEKit)
 20  0x00000001063269a5 -[IDEEditorContext _openEditorOpenSpecifier:updateHistory:](in IDEKit)
 21  0x000000010632688b -[IDEEditorContext openEditorOpenSpecifier:](in IDEKit)
 22  0x000000010632676f -[IDEEditorModeViewController openEditorOpenSpecifier:editorContext:](in IDEKit)
 23  0x00000001063265ed -[IDEEditorArea _openEditorOpenSpecifier:editorContext:takeFocus:](in IDEKit)
 24  0x000000010649a001 __108+[IDEEditorCoordinator _doOpenEditorOpenSpecifier:forWorkspaceTabController:editorContext:target:takeFocus:]_block_invoke (in IDEKit)
 25  0x00000001063261a0 +[IDEEditorCoordinator _doOpenWithWorkspaceTabController:editorContext:target:allowFallback:documentURL:usingBlock:](in IDEKit)
 26  0x0000000106325dc9 +[IDEEditorCoordinator _doOpenEditorOpenSpecifier:forWorkspaceTabController:editorContext:target:takeFocus:](in IDEKit)
 27  0x000000010632590a -[_IDEOpenRequest _runIfNecessary](in IDEKit)
 28  0x000000010632578b -[_IDEOpenRequest _enqueueForEventBehavior:](in IDEKit)
 29  0x0000000106325225 +[IDEEditorCoordinator _openRequestForEditorOpenSpecifier:workspaceTabController:editorContext:eventBehavior:takeFocus:](in IDEKit)
 30  0x000000010649a34e __99+[IDEEditorCoordinator _openEditorOpenSpecifier:forWorkspaceTabController:eventBehavior:takeFocus:]_block_invoke (in IDEKit)
 31  0x000000010649b14e +[IDEEditorCoordinator _performBlockInsideReentrantGuard:](in IDEKit)
 32  0x0000000106345554 +[IDEEditorCoordinator _openEditorOpenSpecifier:forWorkspaceTabController:eventBehavior:takeFocus:](in IDEKit)
 33  0x0000000106345391 +[IDEEditorCoordinator openEditorOpenSpecifier:forWorkspaceTabController:eventType:](in IDEKit)
 34  0x000000010b9100d1 -[DBGDebugSessionController _navigateToPossiblyNonExistentURL:withStackFrame:withEventType:](in DebuggerUI)
 35  0x000000010b90ff40 __71-[DBGDebugSessionController _navigateEditorToDisassemblyForStackFrame:]_block_invoke (in DebuggerUI)
 36  0x000000010b8acca3 -[DBGStackFrame _provideCachedDisassemblyOnMainThread:](in DebuggerFoundation)
 37  0x00000001052f3683 __DVTSyncPerformBlock_block_invoke (in DVTFoundation)
 38  0x00007fff8825e60c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ (in CoreFoundation)
 39  0x00007fff8824fd25 __CFRunLoopDoBlocks (in CoreFoundation)
 40  0x00007fff8824f61e __CFRunLoopRun (in CoreFoundation)
 41  0x00007fff8824f0b5 CFRunLoopRunSpecific (in CoreFoundation)
 42  0x00007fff83dcda0d RunCurrentEventLoopInMode (in HIToolbox)
 43  0x00007fff83dcd685 ReceiveNextEventCommon (in HIToolbox)
 44  0x00007fff83dcd5bc _BlockUntilNextEventMatchingListInModeWithFilter (in HIToolbox)
 45  0x00007fff859e43de _DPSNextEvent (in AppKit)
 46  0x00007fff859e3a2b -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:](in AppKit)
 47  0x0000000105826631 -[DVTApplication nextEventMatchingMask:untilDate:inMode:dequeue:](in DVTKit)
 48  0x00007fff859d7b2c -[NSApplication run](in AppKit)
 49  0x00007fff859c2913 NSApplicationMain (in AppKit)
 50  0x00007fff885be5fd start (in libdyld.dylib)

abort() called
