### PR TITLE
Avoid crash on jump to swift header file of system framework

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -607,8 +607,10 @@
         if( currentRange.location != prevPlaceHolder.location && currentRange.location == (prevPlaceHolder.location + prevPlaceHolder.length) ){
             //The condition here means that just before current insertion point is a placeholder.
             //So we select the the place holder and its already selected by "selectedPreviousPlaceholder" above
-        }else{
-            [self setSelectedRange:NSMakeRange(currentRange.location-1, 0)];
+        } else if (currentRange.location == 0) {
+            [self setSelectedRange:NSMakeRange(currentRange.location, 0)];
+        } else {
+            [self setSelectedRange:NSMakeRange(currentRange.location - 1, 0)];
         }
     }
     return;


### PR DESCRIPTION
Crash happens when "Jump to Definition" is executed on system component in .swift file.
This patch is just a workaround, so please review and rewrite my implementation.

Xcode version: 6 beta 1
OS version: 10.9.3 and 10.10

```
Process:               Xcode [33390]
Path:                  /Applications/Xcode6-Beta.app/Contents/MacOS/Xcode
Identifier:            com.apple.dt.Xcode
Version:               6.0 (6194.21)
Build Info:            IDEFrameworks_KLONDIKE-6194021000000000~12
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           Xcode [33390]
User ID:               501

PlugIn Path:             /Users/USER/Library/Application Support/Developer/*/XVim
PlugIn Identifier:       net.JugglerShu.XVim
PlugIn Version:          1.01 (1)

Date/Time:             2014-06-07 06:02:07.627 +0900
OS Version:            Mac OS X 10.10 (14A238x)
Report Version:        11
Anonymous UUID:        BE6C6651-A72A-54DA-F25E-CEA4C7FE109C

Sleep/Wake UUID:       3DFD9183-F69B-4C2A-9462-68158BF32777

Time Awake Since Boot: 160000 seconds
Time Since Wake:       1700 seconds

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000

Application Specific Information:
ProductBuildVersion: 6A215l
ASSERTION FAILURE in /SourceCache/DVTFrameworks/DVTFrameworks-6180.20/DVTKit/TextCompletion/DVTCompletingTextView.m:1348
Details:  Attempt to select an invalid range of text: {18446744073709551615, 0}. Text length: 0. (Please file a Radar. OK to Continue from here.)
Object:   <DVTSourceTextView: 0x7fd7f722a270>
Method:   -setSelectedRange:
Thread:   <NSThread: 0x7fd7f2e18b50>{number = 1, name = main}
Hints:   None
Backtrace:
  0  0x000000010f29d83a -[IDEAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] (in IDEKit)
  1  0x000000010e00dfdf _DVTAssertionHandler (in DVTFoundation)
  2  0x000000010e00e2ce _DVTAssertionFailureHandler (in DVTFoundation)
  3  0x000000010e446881 -[DVTCompletingTextView setSelectedRange:] (in DVTKit)
  4  0x000000010e46ff22 -[DVTSourceTextView setSelectedRange:] (in DVTKit)
  5  0x00007fff8b6ce290 _NSSetRangeValueAndNotify (in Foundation)
  6  0x000000011c4c3a31 -[NSTextView(VimOperation) xvim_adjustCursorPosition] at /Users/ishkawa/Desktop/XVim/XVim/NSTextView+VimOperation.m:601 (in XVim)
  7  0x000000011c48c221 -[XVimWindow syncEvaluatorStack] at /Users/ishkawa/Desktop/XVim/XVim/XVimWindow.m:290 (in XVim)
  8  0x000000011c48afea -[XVimWindow _documentChangedNotification:] at /Users/ishkawa/Desktop/XVim/XVim/XVimWindow.m:119 (in XVim)
  9  0x00007fff8855ca5c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ (in CoreFoundation)
 10  0x00007fff8844a5c4 _CFXNotificationPost (in CoreFoundation)
 11  0x00007fff8b5b6761 -[NSNotificationCenter postNotificationName:object:userInfo:] (in Foundation)
 12  0x000000011c453d4e -[XVim observeValueForKeyPath:ofObject:change:context:] at /Users/ishkawa/Desktop/XVim/XVim/XVim.m:233 (in XVim)
 13  0x00007fff8b5bd4b3 NSKeyValueNotifyObserver (in Foundation)
 14  0x00007fff8b5df24f -[NSObject(NSKeyValueObserverRegistration) _addObserver:forProperty:options:context:] (in Foundation)
 15  0x00007fff8b5def6a -[NSObject(NSKeyValueObserverRegistration) addObserver:forKeyPath:options:context:] (in Foundation)
 16  0x000000011c49159d -[IDEEditorHook didSetupEditor] at /Users/ishkawa/Desktop/XVim/XVim/IDEEditorHook.m:28 (in XVim)
 17  0x000000011613ade5 -[IDESourceCodeEditor didSetupEditor] (in IDESourceEditor)
```
