### PR TITLE
Avoid crash on moving cursor near the top of file

### DIFF
--- a/XVim/DVTTextStorage+XVimTextStoring.m
+++ b/XVim/DVTTextStorage+XVimTextStoring.m
@@ -41,7 +41,9 @@
         NSRange range = [self characterRangeForLineRange:NSMakeRange(num - 1, 1)];
 
         xvim_sb_init(&sb, self.xvim_string, range.location, range);
-        xvim_sb_find_backward(&sb, [NSCharacterSet newlineCharacterSet]);
+        if ((NSInteger)sb.s_index >= 0) {
+            xvim_sb_find_backward(&sb, [NSCharacterSet newlineCharacterSet]);
+        }
 
         if (newLineLength) *newLineLength = xvim_sb_range_to_end(&sb).length;
         return xvim_sb_range_to_start(&sb);


### PR DESCRIPTION
Crash occurs when cursor is moved near the top of file, which has short first line, and it happens on both of Xcode 5 and Xcode 6 beta. This patch is a quick fix, because I could not understand how to fix `xvim_sb_init`. The cause of this crash is `sb->s_index` sometimes becomes negative value in `xvim_sb_init`, then `xvim_sb_find_backward` makes infinite loop.

``` objectivec
NS_INLINE void xvim_sb_init(xvim_string_buffer_t *sb, NSString *s, NSUInteger index, NSRange forRange)
{
    sb->s = s;
    sb->s_min = forRange.location;
    sb->s_max = sb->s_min + forRange.length;

    NSCAssert(index >= sb->s_min && index <= sb->s_max, @"bad caller");

    if (forRange.length < _xvim_sb_size() || index - _xvim_sb_size() / 2 < sb->s_min) {
        sb->s_index = sb->s_min;
    } else if (index + _xvim_sb_size() >= sb->s_max) {
        sb->s_index = sb->s_max - _xvim_sb_size() + 1;
    } else {
        // crash if: -2 = 14 - 16
        sb->s_index = index - _xvim_sb_size() / 2;
    }
    sb->b_index = index - sb->s_index;
    _xvim_sb_load(sb);
}
```

```
Process:               Xcode [2357]
Path:                  /Applications/Xcode6-Beta.app/Contents/MacOS/Xcode
Identifier:            com.apple.dt.Xcode
Version:               6.0 (6194.21)
Build Info:            IDEFrameworks_KLONDIKE-6194021000000000~12
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           Xcode [2357]
User ID:               501

PlugIn Path:             /Users/USER/Library/Application Support/Developer/*/XVim
PlugIn Identifier:       net.JugglerShu.XVim
PlugIn Version:          1.01 (1)

Date/Time:             2014-06-07 17:44:47.169 +0900
OS Version:            Mac OS X 10.10 (14A238x)
Report Version:        11
Anonymous UUID:        BE6C6651-A72A-54DA-F25E-CEA4C7FE109C


Time Awake Since Boot: 2400 seconds

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x00007ff1f93fffef

VM Regions Near 0x7ff1f93fffef:
    MALLOC_TINY            00007ff1ed000000-00007ff1ed100000 [ 1024K] rw-/rwx SM=PRV  
--> 
    MALLOC_TINY            00007ff1f9400000-00007ff1f9500000 [ 1024K] rw-/rwx SM=PRV  

Application Specific Information:
ProductBuildVersion: 6A215l

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   com.apple.CoreFoundation        0x00007fff8d956440 __CFStrConvertBytesToUnicode + 16
1   com.apple.CoreFoundation        0x00007fff8d97752c _CFStringCheckAndGetCharacters + 236
2   com.apple.CoreFoundation        0x00007fff8d9773e2 -[__NSCFString getCharacters:range:] + 34
3   net.JugglerShu.XVim             0x0000000118d18c7e -[DVTTextStorage(XVimTextStoring) xvim_indexRangeForLineNumber:newLineLength:] + 761 (DVTTextStorage+XVimTextStoring.m:44)
4   net.JugglerShu.XVim             0x0000000118d19e5e -[NSTextStorage(VimOperation) xvim_indexOfLineNumber:] + 27 (NSTextStorage+VimOperation.m:132)
5   net.JugglerShu.XVim             0x0000000118d1a38e -[NSTextStorage(VimOperation) xvim_indexOfLineNumber:column:] + 39 (NSTextStorage+VimOperation.m:204)
6   net.JugglerShu.XVim             0x0000000118d26067 -[NSTextView(VimOperationPrivate) xvim_getMotionRange:Motion:] + 712 (NSTextView+VimOperation.m:2174)
7   net.JugglerShu.XVim             0x0000000118d1ffd9 -[NSTextView(VimOperation) xvim_move:] + 59 (NSTextView+VimOperation.m:626)
8   net.JugglerShu.XVim             0x0000000118cee5c7 -[XVimNormalEvaluator motionFixed:] + 43 (XVimNormalEvaluator.m:516)
9   net.JugglerShu.XVim             0x0000000118cf95c4 -[XVimNumericEvaluator eval:] + 330 (XVimNumericEvaluator.m:47)
10  net.JugglerShu.XVim             0x0000000118d09e3a -[XVimWindow handleKeyStroke:onStack:] + 232 (XVimWindow.m:237)
11  net.JugglerShu.XVim             0x0000000118d09940 -[XVimWindow handleOneXVimString:] + 333 (XVimWindow.m:183)
12  net.JugglerShu.XVim             0x0000000118d09b48 -[XVimWindow handleXVimString:] + 219 (XVimWindow.m:202)
13  net.JugglerShu.XVim             0x0000000118d097e7 -[XVimWindow handleKeyEvent:] + 174 (XVimWindow.m:170)
```
