### PR TITLE
A few more notes about alwaysuseinputsource option

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -177,7 +177,7 @@ The dot command ('.') is supported.
   clipboard | ":set clipboard=unnamed" to share system clipboard with unnamed register
   [no]vimregex | Tells XVim to use Vim's regular expression. Currently support \<,\> for word boundary, \c,\C for specifying case (in)sensitiveness.
   [no]relativenumber |
-  [no]alwaysuseinputsource | With this option all the input is first sent to input source of the system. If you are using France or Portgeses keyboard consider turning this on. (See issue https://github.com/JugglerShu/XVim/issues/598)
+  [no]alwaysuseinputsource | With this option all the input is first sent to input source of the system. If you are using France, Portugese or Swedish keyboard consider turning this on. When enabling this, also consider running `defaults write com.apple.dt.Xcode ApplePressAndHoldEnabled -bool false` to disable the press and hold character menu in recent OS X releases.  (See issue https://github.com/JugglerShu/XVim/issues/598).
   [no]blinkcursor |
 
 


### PR DESCRIPTION
alwaysuseinputsource is needed for Swedish keyboards, and greatly enhanced by disabling the press and hold character menu.

This is information you can find through the referenced issue, but I feel it's important enough to put it in here.
