### PR TITLE
Implement only, quit and cquit window commands; make splitting assistant...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ XVim.xcodeproj/xcuserdata/
 XVim.xcodeproj/project.xcworkspace/xcuserdata/
 .DS_Store
 Gemfile.lock
+build
+*.xccheckout
+

--- a/XVim/IDEWorkspaceTabController+XVim.h
+++ b/XVim/IDEWorkspaceTabController+XVim.h
@@ -19,4 +19,5 @@
 - (void)xvim_moveFocusRight;
 - (void)xvim_removeAssistantEditor;
 - (void)xvim_closeOtherEditors;
+- (void)xvim_closeCurrentEditor;
 @end

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -532,7 +532,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"vnoremap", @"vnoremap:inWindow:"),
                        CMD(@"vnew", @"splitview:inWindow:"),
                        CMD(@"vnoremenu", @"menu:inWindow:"),
-                       CMD(@"vsplit", @"splitview:inWindow:"),
+                       CMD(@"vsplit", @"vsplitview:inWindow:"),
                        CMD(@"vunmap", @"vunmap:inWindow:"),
                        CMD(@"vunmenu", @"menu:inWindow:"),
                        CMD(@"write", @"write:inWindow:"),
@@ -880,6 +880,11 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     [self mapClearMode:XVIM_MODE_CMDLINE];
 }
 
+- (void)cquit:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [window setForcusBackToSourceView];
+    [XVimLastActiveWorkspaceTabController() xvim_closeCurrentEditor];
+}
+
 - (void)debug:(XVimExArg*)args inWindow:(XVimWindow*)window{
     NSMutableArray* params = [NSMutableArray arrayWithArray:[args.arg componentsSeparatedByString:@" "]];
     if( [params count] == 0 ){
@@ -1083,6 +1088,11 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 	[self mapMode:XVIM_MODE_OPERATOR_PENDING withArgs:args remap:YES];
 }
 
+- (void)only:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [window setForcusBackToSourceView];
+    [XVimLastActiveWorkspaceTabController() xvim_closeOtherEditors];
+}
+
 - (void)onoremap:(XVimExArg*)args inWindow:(XVimWindow*)window{
 	[self mapMode:XVIM_MODE_OPERATOR_PENDING withArgs:args remap:NO];
 }
@@ -1109,7 +1119,8 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 }
 
 - (void)quit:(XVimExArg*)args inWindow:(XVimWindow*)window{ // :q
-    [NSApp sendAction:@selector(closeDocument:) to:nil from:self];
+    [window setForcusBackToSourceView];
+    [XVimLastActiveWorkspaceTabController() xvim_closeCurrentEditor];
 }
 
 - (void)reg:(XVimExArg*)args inWindow:(XVimWindow*)window{

--- a/XVim/XVimWindowEvaluator.m
+++ b/XVim/XVimWindowEvaluator.m
@@ -18,7 +18,7 @@
 
 
 - (XVimEvaluator*)c{
-    [XVimLastActiveWorkspaceTabController() xvim_removeAssistantEditor];
+        [XVimLastActiveWorkspaceTabController() xvim_closeCurrentEditor];
     return nil;
 }
 
@@ -38,7 +38,7 @@
 }
 
 - (XVimEvaluator*)q{
-    [XVimLastActiveWorkspaceTabController() xvim_removeAssistantEditor];
+    [XVimLastActiveWorkspaceTabController() xvim_closeCurrentEditor];
     return nil;
 }
 


### PR DESCRIPTION
Hi, now XVim is ARC-ified, I'm finally working off the official XVim branches, so I can start contributing again.

Here's a pull request to implement some missing/incomplete window commands: only, quit and cquit. 

I also made the splitting more vim-like: e.g. if you just keep doing vsplit, you keep getting editors opening on the right. For split, you keep getting editors opening below.

Cheers
--Anthony
