### PR TITLE
Preliminary support for 'R' mode

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2616859E1A3E1962007AA008 /* XVimReplaceEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = 2616859D1A3E1962007AA008 /* XVimReplaceEvaluator.m */; };
 		6E2B332D1836E42F00EFE4E2 /* XVimBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2B332B1836E42F00EFE4E2 /* XVimBuffer.m */; };
 		6E2B33341836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2B33331836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.m */; };
 		A204814F19702F3E0064BE66 /* NSObject+XVimAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A204814E19702F3E0064BE66 /* NSObject+XVimAdditions.m */; };
@@ -124,6 +125,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2616859C1A3E1962007AA008 /* XVimReplaceEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimReplaceEvaluator.h; path = XVim/XVimReplaceEvaluator.h; sourceTree = SOURCE_ROOT; };
+		2616859D1A3E1962007AA008 /* XVimReplaceEvaluator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimReplaceEvaluator.m; path = XVim/XVimReplaceEvaluator.m; sourceTree = SOURCE_ROOT; };
 		6E2B332A1836E42F00EFE4E2 /* XVimBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimBuffer.h; path = XVim/XVimBuffer.h; sourceTree = SOURCE_ROOT; };
 		6E2B332B1836E42F00EFE4E2 /* XVimBuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimBuffer.m; path = XVim/XVimBuffer.m; sourceTree = SOURCE_ROOT; };
 		6E2B332E1836E47500EFE4E2 /* XVimTextStoring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimTextStoring.h; path = XVim/XVimTextStoring.h; sourceTree = SOURCE_ROOT; };
@@ -544,6 +547,8 @@
 				C3552D9A153948D200D57577 /* XVimCommandLineEvaluator.m */,
 				A2AFD7321790F2FD009B442B /* XVimRecordingEvaluator.h */,
 				A2AFD7331790F2FF009B442B /* XVimRecordingEvaluator.m */,
+				2616859C1A3E1962007AA008 /* XVimReplaceEvaluator.h */,
+				2616859D1A3E1962007AA008 /* XVimReplaceEvaluator.m */,
 			);
 			name = "Event Handlers(Evaluators)";
 			sourceTree = "<group>";
@@ -813,6 +818,7 @@
 				A28F426917EEDBC200A3F7AE /* XVimRecordingEvaluator.m in Sources */,
 				A28F426A17EEDBC200A3F7AE /* XVimTester+Recording.m in Sources */,
 				A28F426B17EEDBC200A3F7AE /* XVimTester+Issues.m in Sources */,
+				2616859E1A3E1962007AA008 /* XVimReplaceEvaluator.m in Sources */,
 				A28F426C17EEDBC200A3F7AE /* NSTextStorage+VimOperation.m in Sources */,
 				A28F426D17EEDBC200A3F7AE /* NSTextView+VimOperation.m in Sources */,
 				A28F426E17EEDBC200A3F7AE /* XVimTester+ExCmd.m in Sources */,

--- a/XVim.xcodeproj/xcshareddata/xcschemes/XVim for Xcode5 and 6.xcscheme
+++ b/XVim.xcodeproj/xcshareddata/xcschemes/XVim for Xcode5 and 6.xcscheme
@@ -42,15 +42,6 @@
       <PathRunnable
          FilePath = "/Applications/Xcode.app">
       </PathRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A28F422617EEDBC200A3F7AE"
-            BuildableName = "XVim.xcplugin"
-            BlueprintName = "XVim for Xcode5 and 6"
-            ReferencedContainer = "container:XVim.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/XVim.xcodeproj/xcshareddata/xcschemes/XVim for Xcode5 and 6.xcscheme
+++ b/XVim.xcodeproj/xcshareddata/xcschemes/XVim for Xcode5 and 6.xcscheme
@@ -42,6 +42,15 @@
       <PathRunnable
          FilePath = "/Applications/Xcode.app">
       </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A28F422617EEDBC200A3F7AE"
+            BuildableName = "XVim.xcplugin"
+            BlueprintName = "XVim for Xcode5 and 6"
+            ReferencedContainer = "container:XVim.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/XVim/Test/XVimTester+Operator.m
+++ b/XVim/Test/XVimTester+Operator.m
@@ -140,6 +140,16 @@
                                  @"bbb\n"
                                  @"ccc";
     
+    static NSString* R_result1 = @"aXX bbb ccc\n";
+    static NSString* R_result2 = @"aXXXXXX ccc\n";
+    static NSString* R_result3 = @"XYXYXYb ccc\n";
+    static NSString* R_result4 = @"aXa\n"
+                                 @"bbb\n"
+                                 @"ccc"; 
+    static NSString* R_result5 = @"aXa\n"
+                                 @"bbb\n"
+                                 @"ccc";
+    
     static NSString* s_result1 = @"aaaaa bbb ccc\n";
     static NSString* s_result2 = @"aaa bbb ccc\n";
     static NSString* s_result3 = @"aaaa\n"
@@ -466,6 +476,13 @@
             XVimMakeTestCase(text0, 5,  0, @"rXl.l.", r_result3, 7, 0), // Repeat
             XVimMakeTestCase(text1, 1,  0, @"rXjj`^", r_result4, 2, 0), // ^ Mark
             XVimMakeTestCase(text1, 1,  0, @"rXjj`.", r_result5, 1, 0), // . Mark
+            
+            // R
+            XVimMakeTestCase(text0, 1,  0, @"RXX<ESC>",     R_result1, 2, 0),
+            XVimMakeTestCase(text0, 1,  0, @"3RXX<ESC>",    R_result2, 6, 0), // Numeric arg
+            XVimMakeTestCase(text0, 0,  0, @"RXY<ESC>l.l.", R_result3, 5, 0), // Repeat
+            XVimMakeTestCase(text1, 1,  0, @"RX<ESC>jj`^",  R_result4, 2, 0), // ^ Mark
+            XVimMakeTestCase(text1, 1,  0, @"RX<ESC>jj`.",  R_result5, 1, 0), // . Mark
             
             // s
             XVimMakeTestCase(text0, 1, 0, @"saaa<ESC>"   , s_result1,  3, 0),

--- a/XVim/XVimGActionEvaluator.m
+++ b/XVim/XVimGActionEvaluator.m
@@ -62,7 +62,7 @@
             mode = XVIM_INSERT_APPEND;
         }
     }
-	return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:mode] autorelease];
+	return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:mode] autorelease];
 }
 
 - (XVimEvaluator*)J{

--- a/XVim/XVimInsertEvaluator.h
+++ b/XVim/XVimInsertEvaluator.h
@@ -10,6 +10,6 @@
 
 @interface XVimInsertEvaluator : XVimEvaluator
 
-- (id)initWithWindow:(XVimWindow *)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode;
+- (id)initWithWindow:(XVimWindow *)window mode:(XVimInsertionPoint)mode;
 
 @end

--- a/XVim/XVimInsertEvaluator.m
+++ b/XVim/XVimInsertEvaluator.m
@@ -32,7 +32,6 @@
 @implementation XVimInsertEvaluator{
     BOOL _insertedEventsAbort;
     NSMutableArray* _insertedEvents;
-    BOOL _oneCharMode;
     NSUInteger _blockEditColumn;
     XVimRange _blockLines;
     XVimInsertionPoint _mode;
@@ -47,17 +46,16 @@
 
 
 - (id)initWithWindow:(XVimWindow *)window{
-    return [self initWithWindow:window oneCharMode:NO mode:XVIM_INSERT_DEFAULT];
+    return [self initWithWindow:window mode:XVIM_INSERT_DEFAULT];
 }
 
-- (id)initWithWindow:(XVimWindow*)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode{
+- (id)initWithWindow:(XVimWindow*)window mode:(XVimInsertionPoint)mode{
     self = [super initWithWindow:window];
     if (self) {
         _mode = mode;
         _blockEditColumn = NSNotFound;
         _blockLines = XVimMakeRange(NSNotFound, NSNotFound);
         _lastInsertedText = [@"" retain];
-        _oneCharMode = oneCharMode;
         _movementKeyPressed = NO;
         _insertedEventsAbort = NO;
         _enoughBufferForReplace = YES;
@@ -95,27 +93,6 @@
     [super becameHandler];
     [self.sourceView xvim_insert:_mode blockColumn:&_blockEditColumn blockLines:&_blockLines];
     self.startRange = [[self sourceView] selectedRange];
-}
-
-- (float)insertionPointHeightRatio{
-    if(_oneCharMode){
-        return 0.25;
-    }
-    return 1.0;
-}
-
-- (float)insertionPointWidthRatio{
-    if(_oneCharMode){
-        return 1.0;
-    }
-    return 0.15;
-}
-
-- (float)insertionPointAlphaRatio{
-    if(_oneCharMode){
-        return 0.5;
-    }
-    return 1.0;
 }
 
 - (XVimKeymap*)selectKeymapWithProvider:(id<XVimKeymapProvider>)keymapProvider{
@@ -174,29 +151,32 @@
     self.startRange = [[self sourceView] selectedRange];
 }
 
+- (void)repeatBlockText {
+    NSString *text = [self insertedText];
+    for( int i = 0 ; i < [self numericArg]-1; i++ ){
+        [self.sourceView insertText:text];
+    }
+
+    if (_blockEditColumn != NSNotFound) {
+        XVimRange range = XVimMakeRange(_blockLines.begin + 1, _blockLines.end);
+        [self.sourceView xvim_blockInsertFixupWithText:text mode:_mode count:self.numericArg
+                                                column:_blockEditColumn lines:range];
+    }
+}
+
 - (void)didEndHandler{
     [super didEndHandler];
 	NSTextView *sourceView = [self sourceView];
 
-    if( !_insertedEventsAbort && !_oneCharMode ){
-        NSString *text = [self insertedText];
-        for( int i = 0 ; i < [self numericArg]-1; i++ ){
-            [sourceView insertText:text];
-        }
-
-        if (_blockEditColumn != NSNotFound) {
-            XVimRange range = XVimMakeRange(_blockLines.begin + 1, _blockLines.end);
-            [sourceView xvim_blockInsertFixupWithText:text mode:_mode count:self.numericArg
-                                               column:_blockEditColumn lines:range];
-        }
+    if( !_insertedEventsAbort ){
+        [self repeatBlockText];
     }
 
     // Store off any needed text
     XVim *xvim = [XVim instance];
     xvim.lastVisualMode = self.sourceView.selectionMode;
     [xvim fixOperationCommands];
-    if( _oneCharMode ){
-    }else if (!self.movementKeyPressed){
+    if (!self.movementKeyPressed){
         //[self recordTextIntoRegister:xvim.recordingRegister];
         //[self recordTextIntoRegister:xvim.repeatRegister];
     }else if(self.lastInsertedText.length > 0){
@@ -243,13 +223,7 @@
     
     if (nextEvaluator == self && nil == keySelector){
         NSEvent *event = [keyStroke toEventwithWindowNumber:0 context:nil];
-        if (_oneCharMode) {
-            if( ![self.sourceView xvim_replaceCharacters:keyStroke.character count:[self numericArg]] ){
-                nextEvaluator = [XVimEvaluator invalidEvaluator];
-            }else{
-                nextEvaluator = nil;
-            }
-        } else if ([self windowShouldReceive:keySelector]) {
+        if ([self windowShouldReceive:keySelector]) {
             // Here we pass the key input to original text view.
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'

--- a/XVim/XVimNormalEvaluator.m
+++ b/XVim/XVimNormalEvaluator.m
@@ -16,6 +16,7 @@
 #import "XVimShiftEvaluator.h"
 #import "XVimDeleteEvaluator.h"
 #import "XVimInsertEvaluator.h"
+#import "XVimReplaceEvaluator.h"
 #import "XVimRegisterEvaluator.h"
 #import "XVimWindowEvaluator.h"
 #import "XVimGActionEvaluator.h"
@@ -76,11 +77,11 @@
 // Command which results in cursor motion should be implemented in XVimMotionEvaluator
 
 - (XVimEvaluator*)a{
-	return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_APPEND] autorelease];
+	return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_APPEND] autorelease];
 }
 
 - (XVimEvaluator*)A{
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_APPEND_EOL] autorelease];
+    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_APPEND_EOL] autorelease];
 }
 
 - (XVimEvaluator*)C_a{
@@ -185,7 +186,7 @@
 }
 
 - (XVimEvaluator*)I{
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_BEFORE_FIRST_NONBLANK] autorelease];
+    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BEFORE_FIRST_NONBLANK] autorelease];
 }
 
 - (XVimEvaluator*)J{
@@ -271,8 +272,13 @@
 }
 
 - (XVimEvaluator*)r{
-	[self.argumentString appendString:@"r"];
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:YES mode:XVIM_INSERT_DEFAULT] autorelease];
+    [self.argumentString appendString:@"r"];
+    return [[[XVimReplaceEvaluator alloc] initWithWindow:self.window oneCharMode:YES mode:XVIM_INSERT_DEFAULT] autorelease];
+}
+
+- (XVimEvaluator*)R{
+    [self.argumentString appendString:@"R"];
+    return [[[XVimReplaceEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_DEFAULT] autorelease];
 }
 
 - (XVimEvaluator*)s{

--- a/XVim/XVimReplaceEvaluator.h
+++ b/XVim/XVimReplaceEvaluator.h
@@ -1,0 +1,14 @@
+//
+//  XVimReplaceEvaluator.h
+//  XVim
+//
+//  Created by Martin Conte Mac Donell on 12/14/14.
+//
+
+#import "XVimInsertEvaluator.h"
+
+@interface XVimReplaceEvaluator : XVimInsertEvaluator
+
+- (id)initWithWindow:(XVimWindow *)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode;
+
+@end

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -42,11 +42,11 @@
 }
 
 - (NSString*)modeString{
-    return oneCharMode ? @"" :  @"-- REPLACE --";
+    return self.oneCharMode ? @"" :  @"-- REPLACE --";
 }
 
 - (void)repeatBlockText{
-    if (oneCharMode) {
+    if (self.oneCharMode) {
         return;
     }
 
@@ -63,14 +63,14 @@
     XVimEvaluator *nextEvaluator = keySelector ? [self performSelector:keySelector] : self;
 
     if (nextEvaluator == self && nil == keySelector){
-        if (oneCharMode || [self windowShouldReceive:keySelector]) {
+        if (self.oneCharMode || [self windowShouldReceive:keySelector]) {
             // Here we pass the key input to original text view.
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'
-            if (oneCharMode || (keyStroke.modifier == 0 && isPrintable(keyStroke.character))) {
+            if (self.oneCharMode || (keyStroke.modifier == 0 && isPrintable(keyStroke.character))) {
                 if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];
-                } else if (oneCharMode) {
+                } else if (self.oneCharMode) {
                     nextEvaluator = nil;
                 }
             } else {

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -56,6 +56,22 @@
     }
 }
 
+- (void)didEndHandler {
+    [super didEndHandler];
+
+    NSUndoManager *undoManager = [[self sourceView] undoManager];
+    [undoManager endUndoGrouping];
+    [undoManager setGroupsByEvent:YES];
+}
+
+- (void)becameHandler {
+    [super becameHandler];
+
+    NSUndoManager *undoManager = [[self sourceView] undoManager];
+    [undoManager setGroupsByEvent:NO];
+    [undoManager beginUndoGrouping];
+}
+
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
     SEL keySelector = [keyStroke selectorForInstance:self];
     XVimEvaluator *nextEvaluator = keySelector ? [self performSelector:keySelector] : self;

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -8,12 +8,16 @@
 #import "XVimReplaceEvaluator.h"
 #import "XVimWindow.h"
 
-@interface XVimInsertEvaluator()
-
-@property (nonatomic) BOOL oneCharMode;
+@interface XVimInsertEvaluator ()
 
 - (NSString*)insertedText;
 - (BOOL)windowShouldReceive:(SEL)keySelector;
+
+@end
+
+@interface XVimReplaceEvaluator ()
+
+@property (nonatomic, assign) BOOL oneCharMode;
 
 @end
 
@@ -34,7 +38,7 @@
 - (id)initWithWindow:(XVimWindow*)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode{
     self = [super initWithWindow:window mode:mode];
     if (self) {
-        self.oneCharMode = oneCharMode;
+        _oneCharMode = oneCharMode;
     }
     return self;
 }

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -48,10 +48,6 @@
 }
 
 - (void)repeatBlockText{
-    if (self.oneCharMode) {
-        return;
-    }
-
     NSString *text = [self insertedText];
     NSTextView *sourceView = [self sourceView];
     

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -1,0 +1,95 @@
+//
+//  XVimReplaceEvaluator.m
+//  XVim
+//
+//  Created by Martin Conte Mac Donell on 12/14/14.
+//
+
+#import "XVimReplaceEvaluator.h"
+#import "XVimWindow.h"
+
+@interface XVimInsertEvaluator()
+
+@property (nonatomic) NSRange startRange;
+@property (nonatomic) BOOL movementKeyPressed;
+
+- (NSString*)insertedText;
+- (BOOL)windowShouldReceive:(SEL)keySelector;
+
+@end
+
+@implementation XVimReplaceEvaluator {
+    BOOL _oneCharMode;
+}
+
+- (float)insertionPointHeightRatio{
+    return 0.25;
+}
+
+- (float)insertionPointWidthRatio{
+    return 1.0;
+}
+
+- (float)insertionPointAlphaRatio{
+    return 0.5;
+}
+
+- (id)initWithWindow:(XVimWindow*)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode{
+    self = [super initWithWindow:window mode:mode];
+    if (self) {
+        _oneCharMode = oneCharMode;
+    }
+    return self;
+}
+
+- (NSString*)modeString{
+	return @"-- REPLACE --";
+}
+
+- (void)abc {
+    if (_oneCharMode) {
+        return;
+    }
+
+    NSString *text = [self insertedText];
+    NSTextView *sourceView = [self sourceView];
+    
+    for (int i = 0 ; i < [self numericArg]-1; i++) {
+        [sourceView insertText:text replacementRange:NSMakeRange(self.sourceView.insertionPoint, text.length)];
+    }
+}
+
+- (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
+    XVimEvaluator *nextEvaluator = self;
+    SEL keySelector = [keyStroke selectorForInstance:self];
+    if (keySelector){
+        nextEvaluator = [self performSelector:keySelector];
+    }else if(self.movementKeyPressed){
+        // Flag movement key as not pressed until the next movement key is pressed
+        self.movementKeyPressed = NO;
+        
+        // Store off the new start range
+        self.startRange = [[self sourceView] selectedRange];
+    }
+
+    if (nextEvaluator == self && nil == keySelector){
+        if (_oneCharMode || [self windowShouldReceive:keySelector]) {
+            // Here we pass the key input to original text view.
+            // The input coming to this method is already handled by "Input Method"
+            // and the input maight be non ascii like 'あ'
+            if( _oneCharMode || (keyStroke.modifier == 0 && isPrintable(keyStroke.character))){
+                if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
+                    nextEvaluator = [XVimEvaluator invalidEvaluator];
+                } else if (_oneCharMode) {
+                    nextEvaluator = nil;
+                }
+            } else {
+                NSEvent *event = [keyStroke toEventwithWindowNumber:0 context:nil];
+                [self.sourceView interpretKeyEvents:[NSArray arrayWithObject:event]];
+            }
+        }
+    }
+    return nextEvaluator;
+}
+
+@end

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -17,9 +17,7 @@
 
 @end
 
-@implementation XVimReplaceEvaluator{
-    BOOL _oneCharMode;
-}
+@implementation XVimReplaceEvaluator
 
 - (float)insertionPointHeightRatio{
     return 0.25;
@@ -36,7 +34,7 @@
 - (id)initWithWindow:(XVimWindow*)window oneCharMode:(BOOL)oneCharMode mode:(XVimInsertionPoint)mode{
     self = [super initWithWindow:window mode:mode];
     if (self) {
-        _oneCharMode = oneCharMode;
+        self.oneCharMode = oneCharMode;
     }
     return self;
 }

--- a/XVim/XVimVisualEvaluator.m
+++ b/XVim/XVimVisualEvaluator.m
@@ -159,7 +159,7 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
 }
 
 - (XVimEvaluator*)A{
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_APPEND] autorelease];
+    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_APPEND] autorelease];
 }
 
 - (XVimEvaluator*)i{
@@ -182,7 +182,7 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
 
 - (XVimEvaluator*)c{
     if (self.sourceView.selectionMode == XVIM_VISUAL_BLOCK) {
-        return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_BLOCK_KILL] autorelease];
+        return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BLOCK_KILL] autorelease];
     }
     XVimDeleteEvaluator* eval = [[[XVimDeleteEvaluator alloc] initWithWindow:self.window insertModeAtCompletion:YES] autorelease];
     return [eval executeOperationWithMotion:XVIM_MAKE_MOTION(MOTION_NONE, CHARACTERWISE_EXCLUSIVE, MOTION_OPTION_NONE, 1)];
@@ -193,7 +193,7 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
         [self.sourceView xvim_changeSelectionMode:XVIM_VISUAL_LINE];
         return [self c];
     }
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_BLOCK_KILL_EOL] autorelease];
+    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BLOCK_KILL_EOL] autorelease];
 }
 
 - (XVimEvaluator*)C_b{
@@ -247,9 +247,9 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
 
 - (XVimEvaluator*)I{
     if (self.sourceView.selectionMode != XVIM_VISUAL_BLOCK) {
-        return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_BEFORE_FIRST_NONBLANK] autorelease];
+        return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BEFORE_FIRST_NONBLANK] autorelease];
     }
-    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window oneCharMode:NO mode:XVIM_INSERT_DEFAULT] autorelease];
+    return [[[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_DEFAULT] autorelease];
 }
 
 - (XVimEvaluator*)J{


### PR DESCRIPTION
Hey, this is a preliminary support for REPLACE mode. I moved the "oneChar" boolean to a new ReplaceEvaluator. It works but there are a couple of things missing:

* ~~'u' should undo the entire block not char by char.~~
* When replacing, we should never replacing the newline (end of line). This is an existing bug on the 'r' mode as well.
* When entering "backspace" on R mode, vim shows the previous char instead (again, this also is a problem with the existing 'r' mode)

Other than, I think it's a good idea to create a new evaluator for the Replace Mode instead of having a bool on insert. What do you guys think?