### PR TITLE
Fix Shift-O on the last line of the file

### DIFF
--- a/XVim/NSTextStorage+VimOperation.m
+++ b/XVim/NSTextStorage+VimOperation.m
@@ -249,7 +249,7 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t *sb, NSUInteger tab
 {
     NSUInteger pos = [self xvim_startOfLine:index];
 
-    if (pos == index && isNewline([self.xvim_string characterAtIndex:pos])) {
+    if (pos == index && isNewline([self.xvim_string characterAtIndex:(pos - 1)])) {
         return NSNotFound;
     }
     return pos;

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -380,7 +380,7 @@
  **/
 
 - (NSUInteger)insertionPoint{
-    id ret = [self dataForName:@"insertionPoint"];
+    NSNumber* ret = [self dataForName:@"insertionPoint"];
     return nil == ret ? 0 : [ret unsignedIntegerValue];
 }
 


### PR DESCRIPTION
This fixes an issue where, when the start of the line is the last
character of the file, there an off by 1 error that would cause shift-o
not to work. `characterAtIndex` expects and index within the bounds of
this string, the passed character index was previously the length of the
string.

This fixes #675