### PR TITLE
Add Xcode 6.3 beta support

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -26,6 +26,7 @@
 		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
This adds the UDID of Xcode 6.3 beta. After a build with Xcode, and a restart, Xvim works as expected.

Fixes #685