### PR TITLE
Keystrokes

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -197,12 +197,12 @@
 		A28D895617BFF434002709D8 /* XVimTester+Search.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Search.m"; path = "XVim/Test/XVimTester+Search.m"; sourceTree = SOURCE_ROOT; };
 		A293A38616CE8A8000E1E827 /* XVimDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimDebug.h; path = XVim/XVimDebug.h; sourceTree = SOURCE_ROOT; };
 		A293A38716CE8A8000E1E827 /* XVimDebug.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimDebug.m; path = XVim/XVimDebug.m; sourceTree = SOURCE_ROOT; };
-		A29683FF1A8F03FE00F14667 /* IDESourceEditor.ideplugin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = IDESourceEditor.ideplugin; path = ../../../../Applications/Xcode.app/Contents/PlugIns/IDESourceEditor.ideplugin; sourceTree = "<group>"; };
-		A29684011A8F057800F14667 /* IDESourceEditor */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = IDESourceEditor; path = ../../../../Applications/Xcode.app/Contents/PlugIns/IDESourceEditor.ideplugin/Contents/MacOS/IDESourceEditor; sourceTree = "<group>"; };
-		A29684031A8F06E500F14667 /* IDEFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IDEFoundation.framework; path = ../../../../Applications/Xcode.app/Contents/Frameworks/IDEFoundation.framework; sourceTree = "<group>"; };
-		A29684041A8F06E500F14667 /* IDEKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IDEKit.framework; path = ../../../../Applications/Xcode.app/Contents/Frameworks/IDEKit.framework; sourceTree = "<group>"; };
-		A29684071A8F06FC00F14667 /* DVTFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTFoundation.framework; path = ../../../../Applications/Xcode.app/Contents/SharedFrameworks/DVTFoundation.framework; sourceTree = "<group>"; };
-		A29684081A8F06FC00F14667 /* DVTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTKit.framework; path = ../../../../Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework; sourceTree = "<group>"; };
+		A29683FF1A8F03FE00F14667 /* IDESourceEditor.ideplugin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = IDESourceEditor.ideplugin; path = ../PlugIns/IDESourceEditor.ideplugin; sourceTree = DEVELOPER_DIR; };
+		A29684011A8F057800F14667 /* IDESourceEditor */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = IDESourceEditor; path = ../PlugIns/IDESourceEditor.ideplugin/Contents/MacOS/IDESourceEditor; sourceTree = DEVELOPER_DIR; };
+		A29684031A8F06E500F14667 /* IDEFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IDEFoundation.framework; path = ../Frameworks/IDEFoundation.framework; sourceTree = DEVELOPER_DIR; };
+		A29684041A8F06E500F14667 /* IDEKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IDEKit.framework; path = ../Frameworks/IDEKit.framework; sourceTree = DEVELOPER_DIR; };
+		A29684071A8F06FC00F14667 /* DVTFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTFoundation.framework; path = ../SharedFrameworks/DVTFoundation.framework; sourceTree = DEVELOPER_DIR; };
+		A29684081A8F06FC00F14667 /* DVTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTKit.framework; path = ../SharedFrameworks/DVTKit.framework; sourceTree = DEVELOPER_DIR; };
 		A2A193FF1608E40000809FBE /* XVimTextViewProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XVimTextViewProtocol.h; path = XVim/XVimTextViewProtocol.h; sourceTree = SOURCE_ROOT; };
 		A2A6BA2C152A544B00F0EB5F /* XVimSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimSearch.h; path = XVim/XVimSearch.h; sourceTree = SOURCE_ROOT; };
 		A2A6BA2D152A544B00F0EB5F /* XVimSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimSearch.m; path = XVim/XVimSearch.m; sourceTree = SOURCE_ROOT; };
@@ -849,8 +849,8 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(DEVELOPER_DIR)/../Frameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XVim/XVim-Prefix.pch";
@@ -864,7 +864,7 @@
 				INSTALL_PATH = "";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/PlugIns/IDESourceEditor.ideplugin/Contents/MacOS",
+					"$(DEVELOPER_DIR)/../PlugIns/IDESourceEditor.ideplugin/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = XVim;
@@ -884,8 +884,8 @@
 					"$(inherited)",
 					"$(SYSTEM_APPS_DIR)/Xcode\\ 2.app/Contents/Frameworks",
 					"$(SYSTEM_APPS_DIR)/Xcode\\ 2.app/Contents/SharedFrameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(DEVELOPER_DIR)/../Frameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XVim/XVim-Prefix.pch";
@@ -896,7 +896,7 @@
 				INSTALL_PATH = "";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/PlugIns/IDESourceEditor.ideplugin/Contents/MacOS",
+					"$(DEVELOPER_DIR)/../PlugIns/IDESourceEditor.ideplugin/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = XVim;

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -1343,9 +1343,6 @@
 
         if (lines) *lines = XVimMakeRange(sel.top, sel.bottom);
         switch (mode) {
-            case XVIM_INSERT_BLOCK_KILL_EOL:
-                sel.right = XVimSelectionEOL;
-                /* fallthrough */
             case XVIM_INSERT_BLOCK_KILL:
                 [self _xvim_yankSelection:sel];
                 [self _xvim_killSelection:sel];

--- a/XVim/XVimCommandField.m
+++ b/XVim/XVimCommandField.m
@@ -67,7 +67,7 @@
 }
 
 - (void)handleKeyStroke:(XVimKeyStroke*)keyStroke inWindow:(XVimWindow*)window{
-    if( keyStroke.modifier == 0 && isPrintable(keyStroke.character)){
+    if (keyStroke.isPrintable) {
         [self insertText:keyStroke.xvimString];
         return;
     }

--- a/XVim/XVimCommandLineEvaluator.m
+++ b/XVim/XVimCommandLineEvaluator.m
@@ -103,10 +103,11 @@
 	XVimEvaluator* next = self;
 
 	XVimCommandField *commandField = self.window.commandLine.commandField;
-	if ([keyStroke instanceResponds:self]) {
+    SEL sel = keyStroke.selector;
+    if ([self respondsToSelector:sel]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-		next = [self performSelector:[keyStroke selector]];
+		next = [self performSelector:sel];
 #pragma clang diagnostic pop
 	}
 	else{

--- a/XVim/XVimDefs.h
+++ b/XVim/XVimDefs.h
@@ -26,7 +26,6 @@ typedef NS_ENUM(NSUInteger, XVimInsertionPoint) {
     XVIM_INSERT_BEFORE_FIRST_NONBLANK,
     XVIM_INSERT_APPEND_EOL,
     XVIM_INSERT_BLOCK_KILL,
-    XVIM_INSERT_BLOCK_KILL_EOL,
 };
 
 typedef enum {

--- a/XVim/XVimEvaluator.m
+++ b/XVim/XVimEvaluator.m
@@ -83,8 +83,8 @@ static XVimEvaluator *_popEvaluator = nil;
     // Invokes each key event handler
     // <C-k> invokes "C_k:" selector
 	
-	SEL handler = [keyStroke selectorForInstance:self];
-	if (handler) {
+	SEL handler = keyStroke.selector;
+    if ([self respondsToSelector:handler]) {
 		TRACE_LOG(@"Calling SELECTOR %@", NSStringFromSelector(handler));
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -1057,6 +1057,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 
 - (void)nissue:(XVimExArg*)args inWindow:(XVimWindow*)window{
     [NSApp sendAction:@selector(jumpToNextIssue:) to:nil from:self];
+    [window setForcusBackToSourceView];
 }
 
 - (void)nmap:(XVimExArg*)args inWindow:(XVimWindow*)window{
@@ -1119,6 +1120,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 
 - (void)pissue:(XVimExArg*)args inWindow:(XVimWindow*)window{
     [NSApp sendAction:@selector(jumpToPreviousIssue:) to:nil from:self];
+    [window setForcusBackToSourceView];
 }
 
 - (void)quit:(XVimExArg*)args inWindow:(XVimWindow*)window{ // :q

--- a/XVim/XVimKeyStroke.h
+++ b/XVim/XVimKeyStroke.h
@@ -18,7 +18,6 @@ XVimString* XVimStringFromKeyStrokes(NSArray* strokes);
 NSArray* XVimKeyStrokesFromXVimString(XVimString* string);
 NSArray* XVimKeyStrokesFromKeyNotation(NSString* notation);
 NSString* XVimKeyNotationFromXVimString(XVimString* string);
-BOOL isPrintable(unichar c);
     
 @interface NSEvent(XVimKeyStroke)
 - (XVimKeyStroke*)toXVimKeyStroke;
@@ -29,6 +28,7 @@ BOOL isPrintable(unichar c);
 @property unichar character;
 @property unsigned char modifier;
 @property (nonatomic, readonly) BOOL isNumeric;
+@property (nonatomic, readonly) BOOL isPrintable;
 
 - (id)initWithCharacter:(unichar)c modifier:(unsigned char)mod;
 
@@ -37,26 +37,11 @@ BOOL isPrintable(unichar c);
 // Generates an event from this key stroke
 - (NSEvent*)toEventwithWindowNumber:(NSInteger)num context:(NSGraphicsContext*)context;
 
-// Creates the selector string from this key stroke
-- (NSString*)toSelectorString;
-
 // Creates a human-readable string
 - (NSString*)keyNotation;
 
 // Returns the selector for this object
 - (SEL)selector;
-
-// Returns a selector for the target for this key stroke if one exists
-- (SEL)selectorForInstance:(id)target;
-
-// Returns YES if the instance responds to this key stroke
-- (BOOL)instanceResponds:(id)target;
-
-// Returns YES if the class' instances respond to this key stroke
-- (BOOL)classResponds:(Class)class;
-
-// Returns YES if the class implements this method and does so different to its superclass
-- (BOOL)classImplements:(Class)class;
 
 // Following methods are for to be a key in NSDictionary
 - (NSUInteger)hash;

--- a/XVim/XVimKeyStroke.m
+++ b/XVim/XVimKeyStroke.m
@@ -4,21 +4,23 @@
 //  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
 //
 
+#import <wctype.h>
+#import <xlocale.h>
 #import "XVimKeyStroke.h"
 #import "NSEvent+VimHelper.h"
 #import "Logger.h"
-
+#import "XVimStringBuffer.h"
 
 
 /*
  XVimString and Key Notation
- 
+
  (keymap.h file in Vim source helps understand this better)
- 
+
  XVim uses internal string encoding as Vim does.
- This encoding is not same as any usual character code because 
+ This encoding is not same as any usual character code because
  the encoding include special flags with characters like modifiers.
- 
+
  In Vim they treat all the input as a character.
  This is how recordings or keymapping does work.
  Vim uses internal code(character) to express an input(usually a key stroke).
@@ -26,27 +28,27 @@
  If the key is special like 'backspace' internal expression is 0x80, 'k', 'b' (3byte).
  Vim uses 0x80 as a escape character and followng bytes defines the key.
  Special keys like F1-F10 or S-F1 are all mapped to a 0x80 prefixed value.
- 
+
  Vim always does following convertings.
  [Phisical Key Input] -> [Vim intarnal code]
  [Key Notation in key map] -> [Vim internal code]
 
  Key Notatation here is like <F1> or <BS>.
- 
+
  And Vim interprets the [Vim intarnal code] as input and takes action.
  Printable codes are all stayed same.
  So if you record 'iabc<BS>' the internal code in Vim is 'iabc0x80kb'.
  You can see this when you see the recorded register with :registers
- 
+
  If the key stroke has modifier Vim uses additional byte to represent the modifiers.
- For example for Alt-F2 Vim internal code is like 
+ For example for Alt-F2 Vim internal code is like
  0x80,0xfc(252),0x08,0x80,k,2   where
     - 0x80,0xfc(252) means it has modifier flag and
     - 0x08 means the modifier is Alt
     - 0x80,k,2 is internal code for F2
- 
+
  As Vim does XVim have internal code.
- XVim follows Vim way but the values we use is different. And also we use 
+ XVim follows Vim way but the values we use is different. And also we use
  unichar(2bytes) instead of char in Vim
  This means...
    - Character betwee 0xF800 to 0xF8FF describes modifier flags with lower byte
@@ -54,18 +56,18 @@
    - For special keys like F1, arrow keys XVim does not use the same code with Vim.
      Cocoa defines unichar value for them so we use it instead.
      See  or AppKit/NSEvent.h file
- 
+
  So normal keys like 'a' is just 0x0061 but 'Alt+a' will be 0xF808,0x0061 (4bytes) where 0xF808 represents Alt.
- 
+
  Note that all the key sequences are represented as array of unichar which is 2byte.
  You have to be careful about endian.
  So the value 'Alt+a' will be 0x08 0xF8 0x61 0x00 in byte sequence(each unichar endian is little endian)
  This makes easy to handle key sequence as NSString.
- 
+
  Terminology:
    XVimString - The internal key code explained above.
    Notation - Key input represented by readable string like <C-n> or <BS>...
- 
+
  XVimKeyStroke class:
    This class represents a key input.
    You always can convert XVimString <-> XVimKeyStroke(s).
@@ -74,9 +76,9 @@
    actuall character or modifier flag values.
    XVimString can represents "Sequence" of key input but XVimKeyStroke represents only one key stroke.
    So if XVimString has several key input it will be converted into array of XVimKeyStorke.
- 
+
    In other words you can serialize/deserialize XVimKeyStroke(s) with XVimString
- 
+
  Modifier Flags:
    Following bit mask for modifiers is from NSEvent.h
    We do not use this mask because modifier mask must be fits in 1 byte length.
@@ -119,276 +121,284 @@ static struct key_map key_maps[] = {
     // If multiple key expressions are mapped to one char code
     // Put default key expression at the end of the same keys.
     // The last one will be used when converting charcode -> key expression.
-    {@"NUL", 0, @"NUL"},
-    {@"SOH", 1, @"SOH"},
-    {@"STX", 2, @"STX"},
-    {@"ETX", 3, @"ETX" },
-    {@"EOT", 4, @"EOT"},
-    {@"ENQ", 5, @"ENQ"},
-    {@"ACK", 6, @"ACK"},
-    {@"BEL", 7, @"BEL"},
-    {@"BS",  8, @"BS" },
-    {@"HT",  9, @"TAB"},
-    {@"TAB", 9, @"TAB"}, // Default notation
-    {@"NL",  10, @"NL"},
-    {@"VT",  11, @"VT"},
-    {@"NP",  12, @"NP"},
-    {@"RETURN", 13, @"CR"},
-    {@"ENTER", 13, @"CR"},
-    {@"CR",  13, @"CR"}, // Default notation
-    {@"SO",  14, @"SO"},
-    {@"SI",  15, @"SI"},
-    {@"DLE", 16, @"DLE"},
-    {@"DC1", 17, @"DC1"},
-    {@"DC2", 18, @"DC2"},
-    {@"DC3", 19, @"DC3"},
-    {@"DC4", 20, @"DC4"},
-    {@"NAK", 21, @"NAK"},
-    {@"SYN", 22, @"SYN"},
-    {@"ETB", 23, @"ETB"},
-    {@"CAN", 24, @"CAN"},
-    {@"EM",  25, @"EM"},
-    {@"SUB", 26, @"SUB"},
-    {@"ESC", 27, @"ESC"},
-    {@"FS",  28, @"FS"},
-    {@"GS",  29, @"GS"},
-    {@"RS",  30, @"RS"},
-    {@"US",  31, @"US"},
-    {@"SPACE", 32, @"SPACE"},
-    {@" ", 32, @"SPACE"}, // Default notation
-    {@"!", 33, @"EXCLAMATION"},
-    {@"\"", 34, @"DQUOTE"},
-    {@"#", 35, @"NUMBER"},
-    {@"$", 36, @"DOLLAR"},
-    {@"%", 37, @"PERCENT"},
-    {@"&", 38, @"AMPASAND"},
-    {@"'", 39, @"SQUOTE"},
-    {@"(", 40, @"LPARENTHESIS"},
-    {@")", 41, @"RPARENTHESIS"},
-    {@"*", 42, @"ASTERISK"},
-    {@"+", 43, @"PLUS"},
-    {@",", 44, @"COMMA"},
-    {@"-", 45, @"MINUS"},
-    {@".", 46, @"DOT"},
-    {@"/", 47, @"SLASH"},
-    {@"0", 48, @"NUM0"},
-    {@"1", 49, @"NUM1"},
-    {@"2", 50, @"NUM2"},
-    {@"3", 51, @"NUM3"},
-    {@"4", 52, @"NUM4"},
-    {@"5", 53, @"NUM5"},
-    {@"6", 54, @"NUM6"},
-    {@"7", 55, @"NUM7"},
-    {@"8", 56, @"NUM8"},
-    {@"9", 57, @"NUM9"},
-    {@":", 58, @"COLON"},
-    {@";", 59, @"SEMICOLON"},
-    {@"LT",60, @"LESSTHAN"},
-    {@"<", 60, @"LESSTHAN"}, // Default notation
-    {@"=", 61, @"EQUAL"},
-    {@">", 62, @"GREATERTHAN"},
-    {@"?", 63, @"QUESTION"},
-    {@"@", 64, @"AT"},
-    {@"A", 65, @"A" },
-    {@"B", 66, @"B"},
-    {@"C", 67, @"C"},
-    {@"D", 68, @"D"},
-    {@"E", 69, @"E"},
-    {@"F", 70, @"F"},
-    {@"G", 71, @"G"},
-    {@"H", 72, @"H"},
-    {@"I", 73, @"I"},
-    {@"J", 74, @"J"},
-    {@"K", 75, @"K"},
-    {@"L", 76, @"L"},
-    {@"M", 77, @"M"},
-    {@"N", 78, @"N"},
-    {@"O", 79, @"O"},
-    {@"P", 80, @"P"},
-    {@"Q", 81, @"Q"},
-    {@"R", 82, @"R"},
-    {@"S", 83, @"S"},
-    {@"T", 84, @"T"},
-    {@"U", 85, @"U"},
-    {@"V", 86, @"V"},
-    {@"W", 87, @"W"},
-    {@"X", 88, @"X"},
-    {@"Y", 89, @"Y"},
-    {@"Z", 90, @"Z"},
-    {@"[", 91, @"LSQUAREBRACKET"},
-    {@"BSLASH", 92, @"BACKSLASH"},
-    {@"\\",92, @"BACKSLASH"}, // Default noattion
-    {@"]",93, @"RSQUAREBRACKET"},
-    {@"^",94, @"CARET"},
-    {@"_",95, @"UNDERSCORE"},
-    {@"`",96, @"BACKQUOTE"},
-    {@"a",97, @"a"},
-    {@"b",98, @"b"},
-    {@"c",99, @"c"},
-    {@"d",100, @"d"},
-    {@"e",101, @"e"},
-    {@"f",102, @"f"},
-    {@"g",103, @"g"},
-    {@"h",104, @"h"},
-    {@"i",105, @"i"},
-    {@"j",106, @"j"},
-    {@"k",107, @"k"},
-    {@"l",108, @"l"},
-    {@"m",109, @"m"},
-    {@"n",110, @"n"},
-    {@"o",111, @"o"},
-    {@"p",112, @"p"},
-    {@"q",113, @"q"},
-    {@"r",114, @"r"},
-    {@"s",115, @"s"},
-    {@"t",116, @"t"},
-    {@"u",117, @"u"},
-    {@"v",118, @"v"},
-    {@"w",119, @"w"},
-    {@"x",120, @"x"},
-    {@"y",121, @"y"},
-    {@"z",122, @"z"},
-    {@"{",123, @"LBRACE"},
-    {@"BAR",124, @"BAR"},
-    {@"|",124, @"BAR"}, // Default notation
-    {@"}",125, @"RBRACE"},
-    {@"~",126, @"TILDE"},
-    {@"BS",127, @"BS"},
-    {@"UP",63232, @"Up"},
-    {@"DOWN", 63233, @"Down"},
-    {@"LEFT", 63234, @"Left"},
-    {@"RIGHT", 63235, @"Right"},
-    {@"F1", 63236, @"F1"},
-    {@"F2", 63237, @"F2"},
-    {@"F3", 63238, @"F3"},
-    {@"F4", 63239, @"F4"},
-    {@"F5", 63240, @"F5"},
-    {@"F6", 63241, @"F6"},
-    {@"F7", 63242, @"F7"},
-    {@"F8", 63243, @"F8"},
-    {@"F9", 63244, @"F9"},
-    {@"F10", 63245, @"F10"},
-    {@"F11", 63246, @"F11"},
-    {@"F12", 63247, @"F12"},
-    {@"DEL", 63272, @"DEL"},
-    {@"HOME", 63273, @"Home"},
-    {@"END", 63275, @"End"},
-    {@"PAGEUP", 63276, @"Pageup"},
-    {@"PAGEDOWN", 63277, @"Pagedown"}
+    { @"NUL",        0, @"NUL"},
+    { @"SOH",        1, @"SOH"},
+    { @"STX",        2, @"STX"},
+    { @"ETX",        3, @"ETX" },
+    { @"EOT",        4, @"EOT"},
+    { @"ENQ",        5, @"ENQ"},
+    { @"ACK",        6, @"ACK"},
+    { @"BEL",        7, @"BEL"},
+    { @"BS",         8, @"BS" },
+    { @"HT",         9, @"TAB"},
+    { @"TAB",        9, @"TAB"}, // Default notation
+    { @"NL",        10, @"NL"},
+    { @"VT",        11, @"VT"},
+    { @"NP",        12, @"NP"},
+    { @"RETURN",    13, @"CR"},
+    { @"ENTER",     13, @"CR"},
+    { @"CR",        13, @"CR"}, // Default notation
+    { @"SO",        14, @"SO"},
+    { @"SI",        15, @"SI"},
+    { @"DLE",       16, @"DLE"},
+    { @"DC1",       17, @"DC1"},
+    { @"DC2",       18, @"DC2"},
+    { @"DC3",       19, @"DC3"},
+    { @"DC4",       20, @"DC4"},
+    { @"NAK",       21, @"NAK"},
+    { @"SYN",       22, @"SYN"},
+    { @"ETB",       23, @"ETB"},
+    { @"CAN",       24, @"CAN"},
+    { @"EM",        25, @"EM"},
+    { @"SUB",       26, @"SUB"},
+    { @"ESC",       27, @"ESC"},
+    { @"FS",        28, @"FS"},
+    { @"GS",        29, @"GS"},
+    { @"RS",        30, @"RS"},
+    { @"US",        31, @"US"},
+    { @"SPACE",     32, @"SPACE"},
+    { @" ",         32, @"SPACE"}, // Default notation
+    { @"!",         33, @"EXCLAMATION"},
+    { @"\"",        34, @"DQUOTE"},
+    { @"#",         35, @"NUMBER"},
+    { @"$",         36, @"DOLLAR"},
+    { @"%",         37, @"PERCENT"},
+    { @"&",         38, @"AMPASAND"},
+    { @"'",         39, @"SQUOTE"},
+    { @"(",         40, @"LPARENTHESIS"},
+    { @")",         41, @"RPARENTHESIS"},
+    { @"*",         42, @"ASTERISK"},
+    { @"+",         43, @"PLUS"},
+    { @",",         44, @"COMMA"},
+    { @"-",         45, @"MINUS"},
+    { @".",         46, @"DOT"},
+    { @"/",         47, @"SLASH"},
+    { @"0",         48, @"NUM0"},
+    { @"1",         49, @"NUM1"},
+    { @"2",         50, @"NUM2"},
+    { @"3",         51, @"NUM3"},
+    { @"4",         52, @"NUM4"},
+    { @"5",         53, @"NUM5"},
+    { @"6",         54, @"NUM6"},
+    { @"7",         55, @"NUM7"},
+    { @"8",         56, @"NUM8"},
+    { @"9",         57, @"NUM9"},
+    { @":",         58, @"COLON"},
+    { @";",         59, @"SEMICOLON"},
+    { @"LT",        60, @"LESSTHAN"},
+    { @"<",         60, @"LESSTHAN"}, // Default notation
+    { @"=",         61, @"EQUAL"},
+    { @">",         62, @"GREATERTHAN"},
+    { @"?",         63, @"QUESTION"},
+    { @"@",         64, @"AT"},
+    { @"[",         91, @"LSQUAREBRACKET"},
+    { @"BSLASH",    92, @"BACKSLASH"},
+    { @"\\",        92, @"BACKSLASH"}, // Default noattion
+    { @"]",         93, @"RSQUAREBRACKET"},
+    { @"^",         94, @"CARET"},
+    { @"_",         95, @"UNDERSCORE"},
+    { @"`",         96, @"BACKQUOTE"},
+    { @"{",        123, @"LBRACE"},
+    { @"BAR",      124, @"BAR"},
+    { @"|",        124, @"BAR"}, // Default notation
+    { @"}",        125, @"RBRACE"},
+    { @"~",        126, @"TILDE"},
+    { @"BS",       127, @"BS"},
+
+    { @"UP",            NSUpArrowFunctionKey,       @"Up"           },
+    { @"DOWN",          NSDownArrowFunctionKey,     @"Down"         },
+    { @"LEFT",          NSLeftArrowFunctionKey,     @"Left"         },
+    { @"RIGHT",         NSRightArrowFunctionKey,    @"Right"        },
+    { @"F1",            NSF1FunctionKey,            @"F1"           },
+    { @"F2",            NSF2FunctionKey,            @"F2"           },
+    { @"F3",            NSF3FunctionKey,            @"F3"           },
+    { @"F4",            NSF4FunctionKey,            @"F4"           },
+    { @"F5",            NSF5FunctionKey,            @"F5"           },
+    { @"F6",            NSF6FunctionKey,            @"F6"           },
+    { @"F7",            NSF7FunctionKey,            @"F7"           },
+    { @"F8",            NSF8FunctionKey,            @"F8"           },
+    { @"F9",            NSF9FunctionKey,            @"F9"           },
+    { @"F10",           NSF10FunctionKey,           @"F10"          },
+    { @"F11",           NSF11FunctionKey,           @"F11"          },
+    { @"F12",           NSF12FunctionKey,           @"F12"          },
+    { @"F13",           NSF13FunctionKey,           @"F13"          },
+    { @"F14",           NSF14FunctionKey,           @"F14"          },
+    { @"F15",           NSF15FunctionKey,           @"F15"          },
+    { @"F16",           NSF16FunctionKey,           @"F16"          },
+    { @"F17",           NSF17FunctionKey,           @"F17"          },
+    { @"F18",           NSF18FunctionKey,           @"F18"          },
+    { @"F19",           NSF19FunctionKey,           @"F19"          },
+    { @"F20",           NSF20FunctionKey,           @"F20"          },
+    { @"F21",           NSF21FunctionKey,           @"F21"          },
+    { @"F22",           NSF22FunctionKey,           @"F22"          },
+    { @"F23",           NSF23FunctionKey,           @"F23"          },
+    { @"F24",           NSF24FunctionKey,           @"F24"          },
+    { @"F25",           NSF25FunctionKey,           @"F25"          },
+    { @"F26",           NSF26FunctionKey,           @"F26"          },
+    { @"F27",           NSF27FunctionKey,           @"F27"          },
+    { @"F28",           NSF28FunctionKey,           @"F28"          },
+    { @"F29",           NSF29FunctionKey,           @"F29"          },
+    { @"F30",           NSF30FunctionKey,           @"F30"          },
+    { @"F31",           NSF31FunctionKey,           @"F31"          },
+    { @"F32",           NSF32FunctionKey,           @"F32"          },
+    { @"F33",           NSF33FunctionKey,           @"F33"          },
+    { @"F34",           NSF34FunctionKey,           @"F34"          },
+    { @"F35",           NSF35FunctionKey,           @"F35"          },
+    { @"INS",           NSInsertFunctionKey,        @"Insert"       },
+
+    { @"DEL",           NSDeleteFunctionKey,        @"DEL"          },
+    { @"HOME",          NSHomeFunctionKey,          @"Home"         },
+    { @"BEGIN",         NSBeginFunctionKey,         @"Begin"        },
+    { @"END",           NSEndFunctionKey,           @"End"          },
+    { @"PGUP",          NSPageUpFunctionKey,        @"Pageup"       },
+    { @"PGDN",          NSPageDownFunctionKey,      @"Pagedown"     },
+    { @"PRINTSCREEN",   NSPrintScreenFunctionKey,   @"PrintScreen"  },
+    { @"SCREENLOCK",    NSScrollLockFunctionKey,    @"ScrLock"      },
+    { @"PAUSE",         NSPauseFunctionKey,         @"Pause"        },
+    { @"SYSREQ",        NSSysReqFunctionKey,        @"SysReq"       },
+    { @"BREAK",         NSBreakFunctionKey,         @"Break"        },
+    { @"RESET",         NSResetFunctionKey,         @"Reset"        },
+    { @"STOP",          NSStopFunctionKey,          @"Stop"         },
+    { @"MENU",          NSMenuFunctionKey,          @"Menu"         },
+    { @"USER",          NSUserFunctionKey,          @"User"         },
+    { @"SYSTEM",        NSSystemFunctionKey,        @"System"       },
+    { @"PRINT",         NSPrintFunctionKey,         @"Print"        },
+    { @"CLEARLINE",     NSClearLineFunctionKey,     @"ClearLine"    },
+    { @"CLEARDISPLAY",  NSClearDisplayFunctionKey,  @"ClearDisplay" },
+    { @"INSLINE",       NSInsertLineFunctionKey,    @"InsLine"      },
+    { @"DELLINE",       NSDeleteLineFunctionKey,    @"DelLine"      },
+    { @"INSCHAR",       NSInsertCharFunctionKey,    @"InsChar"      },
+    { @"DELCHAR",       NSDeleteCharFunctionKey,    @"DelChar"      },
+    { @"PREV",          NSPrevFunctionKey,          @"Prev"         },
+    { @"NEXT",          NSNextFunctionKey,          @"Next"         },
+    { @"SELECT",        NSSelectFunctionKey,        @"Select"       },
+    { @"EXECUTE",       NSExecuteFunctionKey,       @"Execute"      },
+    { @"UNDO",          NSUndoFunctionKey,          @"Undo"         },
+    { @"REDO",          NSRedoFunctionKey,          @"Redo"         },
+    { @"FIND",          NSFindFunctionKey,          @"Find"         },
+    { @"HELP",          NSHelpFunctionKey,          @"Help"         },
+    { @"MODESWITCH",    NSModeSwitchFunctionKey,    @"ModeSwitch"   },
+
+    { nil, 0, nil },
 };
 
 static NSMutableDictionary *s_unicharToSelector = nil;
 static NSMutableDictionary *s_keyToUnichar = nil;
 static NSMutableDictionary *s_unicharToKey= nil;
+static locale_t s_locale;
 
-static void initUnicharToSelector(){
-    if( nil == s_unicharToSelector ){
+NS_INLINE void init_maps(void)
+{
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
         s_unicharToSelector = [[NSMutableDictionary alloc] init]; // Never release
-        for( unsigned int i = 0; i < sizeof(key_maps)/sizeof(struct key_map); i++ ){
-            [s_unicharToSelector setObject:key_maps[i].selector forKey:[NSNumber numberWithUnsignedInteger:key_maps[i].c]];
-        }
-    }
-}
-
-static void initKeyToUnichar(){
-    if( nil == s_keyToUnichar){
         s_keyToUnichar = [[NSMutableDictionary alloc] init]; // Never release
-        for( unsigned int i = 0; i < sizeof(key_maps)/sizeof(struct key_map); i++ ){
-            [s_keyToUnichar setObject:[NSNumber numberWithUnsignedInteger:key_maps[i].c] forKey:key_maps[i].key];
-        }
-    }
-}
-
-static void initUnicharToKey(){
-    if( nil == s_unicharToKey){
         s_unicharToKey= [[NSMutableDictionary alloc] init]; // Never release
-        for( unsigned int i = 0; i < sizeof(key_maps)/sizeof(struct key_map); i++ ){
-            [s_unicharToKey setObject:key_maps[i].key forKey:[NSNumber numberWithUnsignedInteger:key_maps[i].c]];
+
+        for (NSUInteger i = 0; key_maps[i].key; i++) {
+            NSNumber *c   = @(key_maps[i].c);
+            NSString *key = key_maps[i].key;
+            NSString *sel = key_maps[i].selector;
+
+            [s_unicharToSelector setObject:sel forKey:c];
+            [s_keyToUnichar      setObject:c   forKey:key];
+            [s_unicharToKey      setObject:key forKey:c];
+            // any UTF-8 works because we ask for iswprint() or wcwidth()
+            s_locale = newlocale(LC_CTYPE_MASK, "en_US.UTF-8", NULL);
         }
-    }
+    });
 }
 
-static BOOL isValidKey(NSString* key){
-    if( nil == s_keyToUnichar ){
-        initKeyToUnichar();
-    }
-    // Notations like <CR>, <SPACE> are all case insensitive
-    if( [key length] > 1 ){
-        key = [key uppercaseString];
-    }
-    return nil != [s_keyToUnichar objectForKey:key];
+NS_INLINE BOOL isNSFunctionKey(unichar c)
+{
+    // see NSEvent.h: OpenStep reserves the range 0xF700-0xF8FF for Function Keys
+    return 0xF700 <= c && c < 0xF900;
 }
 
-static NSString* selectorFromUnichar(unichar c){
-    if( nil == s_unicharToSelector ){
-        initUnicharToSelector();
-    }
-    return [s_unicharToSelector objectForKey:[NSNumber numberWithUnsignedInteger:c]];
+NS_INLINE BOOL isPrintable(unichar c)
+{
+    init_maps();
+
+    return !isNSFunctionKey(c) && iswprint_l(c, s_locale);
 }
 
-static unichar unicharFromKey(NSString* key){
-    if( nil == s_keyToUnichar ){
-        initKeyToUnichar();
-    }
-    
-    if( !isValidKey(key) ){
-        return (unichar)-1;
-    }else{
-        if( [key length] > 1){
-            key = [key uppercaseString];
-        }
-        return [[s_keyToUnichar objectForKey:key] unsignedIntegerValue];
-    }
-}
+NS_INLINE BOOL isValidKey(NSString *key)
+{
+    init_maps();
 
-static NSString* keyFromUnichar(unichar c){
-    if( nil == s_unicharToKey){
-        initUnicharToKey();
-    }
-    NSString* ret = [s_unicharToKey objectForKey:[NSNumber numberWithUnsignedInteger:c]];
-    if( nil == ret ){
-        // We can not convert unichar to known key expression
-        // Try to convert unichar directly to NSString
-        return [NSString stringWithFormat:@"%C", c];
-    }
-    return ret;
-}
-
-BOOL isPrintable(unichar c){
-    // FIXME:
-    // There may be better difinition of printable characters in unicode
-    if( c < 32 || c == 127 || ( 63232 <= c && c <= 63277 ) ){
+    if (key.length == 0) {
         return NO;
     }
-    return YES;
+    if (key.length == 1) {
+        return isPrintable([key characterAtIndex:0]);
+    }
+
+    return [s_keyToUnichar objectForKey:key.uppercaseString] != 0;
 }
 
-static BOOL isModifier(unichar c){
-    return ( XVIM_MODIFIER_MIN <= c && c <= XVIM_MODIFIER_MAX );
+NS_INLINE unichar unicharFromKey(NSString *key)
+{
+    init_maps();
+
+    if (key.length == 0) {
+        return (unichar)-1;
+    }
+    if (key.length == 1) {
+        unichar c = [key characterAtIndex:0];
+
+        return isPrintable(c) ? c : (unichar)-1;
+    }
+
+    return [[s_keyToUnichar objectForKey:key.uppercaseString] unsignedIntegerValue];
 }
 
-static XVimString* MakeXVimString( unichar character, unsigned short modifier){
-    NSMutableString* str = [[NSMutableString alloc] init];
+NS_INLINE NSString *keyFromUnichar(unichar c)
+{
+    init_maps();
+
+    NSString *key = [s_unicharToKey objectForKey:@(c)];
+    if (key) {
+        return key;
+    }
+    if (isPrintable(c)) {
+        return [NSString stringWithCharacters:&c length:1];
+    }
+    return @"?";
+}
+
+NS_INLINE BOOL isModifier(unichar c)
+{
+    return (XVIM_MODIFIER_MIN <= c && c <= XVIM_MODIFIER_MAX);
+}
+
+static XVimString *MakeXVimString(unichar character, unsigned short modifier)
+{
+    NSMutableString *str = [[NSMutableString alloc] init];
+
+    init_maps();
+
     // If the character is pritable we do not consider Shift modifier
     // For example <S-!> and ! is same
-    if( isPrintable(character) ){
+    if (isPrintable(character)) {
         modifier = modifier & ~XVIM_MOD_SHIFT;
     }
-    if( modifier != 0 ){
+    if (modifier != 0) {
         [str appendFormat:@"%C", XVIM_MAKE_MODIFIER(modifier)];
     }
     [str appendFormat:@"%C", character];
     return str;
 }
 
-static XVimString* XVimStringFromKeyNotationImpl(NSString* string, NSUInteger* index){
-	NSUInteger starti = *index;
-	
-	NSUInteger modifierFlags = 0;
+static XVimString *XVimStringFromKeyNotationImpl(NSString *string, NSUInteger *index)
+{
+    NSUInteger starti = *index;
+
+    NSUInteger modifierFlags = 0;
     NSUInteger p = starti;
     NSUInteger length = [string length];
-	if ([string characterAtIndex:starti] == '<') {
-		// Find modifier flags, if any
+
+    if ([string characterAtIndex:starti] == '<') {
+        // Find modifier flags, if any
         p += 1; // skip first '<' letter
         NSRange keyEnd = [string rangeOfString:@">" options:0 range:NSMakeRange(p, length-p)];
         if( keyEnd.location != NSNotFound ){
@@ -416,28 +426,28 @@ static XVimString* XVimStringFromKeyNotationImpl(NSString* string, NSUInteger* i
                 }
                 p+=2;
             }
-        
-            NSString* key = [string substringWithRange:NSMakeRange(p, keyEnd.location-p)];
-            if( isValidKey(key) ){
-                if( 0 == modifierFlags ){
+
+            NSString *key = [string substringWithRange:NSMakeRange(p, keyEnd.location-p)];
+            if (isValidKey(key)) {
+                if (0 == modifierFlags) {
                     //If it does not have modifier flag the key must be multiple letters
-                    if( [key length] > 1 ){
+                    if ([key length] > 1) {
                         *index = keyEnd.location+1;
                         unichar c = unicharFromKey(key);
-                        return MakeXVimString( c, modifierFlags);
+                        return MakeXVimString(c, modifierFlags);
                     }
-                }else{
+                } else {
                     //This is modifier flag + valid key
                     *index = keyEnd.location+1;
                     unichar c = unicharFromKey(key);
-                    return MakeXVimString( c, modifierFlags);
+                    return MakeXVimString(c, modifierFlags);
                 }
             }
         }
         // if it not valid key like "<a>" or "<c>" take first letter "<" as a key
         // Just go through.
     }
-    
+
     // Simple one letter key
     NSString* key = [string substringWithRange:NSMakeRange(starti, 1)];
     unichar c = unicharFromKey(key);
@@ -446,16 +456,16 @@ static XVimString* XVimStringFromKeyNotationImpl(NSString* string, NSUInteger* i
 }
 
 XVimString* XVimStringFromKeyNotation(NSString* notation){
-	NSUInteger index = 0;
-	NSUInteger len = notation.length;
+    NSUInteger index = 0;
+    NSUInteger len = notation.length;
     NSMutableString* str = [[NSMutableString alloc] init];
-	while (index < len){
+    while (index < len){
         XVimString* oneKey = XVimStringFromKeyNotationImpl(notation, &index);
-		if( oneKey == nil ){
+        if( oneKey == nil ){
             break;
         }
         [str appendString:oneKey];
-	}
+    }
     return str;
 }
 
@@ -479,7 +489,7 @@ NSArray* XVimKeyStrokesFromXVimString(XVimString* string){
             c2 = c1;
             c1 = 0;
         }
-        
+
         XVimKeyStroke* stroke = [[XVimKeyStroke alloc] initWithCharacter:c2 modifier:c1];
         [array addObject:stroke];
     }
@@ -506,10 +516,14 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string){
         return nil;
     }
     unichar c = [[self charactersIgnoringModifiers] characterAtIndex:0];
-    // We unset NSFunctionKeyMask bit for function keys (7F00 and above)
     NSUInteger mod = self.modifierFlags;
-    if( c >= 0x7F00 ){
+    if (isNSFunctionKey(c)) {
+        // We unset NSFunctionKeyMask bit for function keys (7F00 and above)
         mod &= (NSUInteger)~NSFunctionKeyMask;
+    }
+    if (c == 0x19 && (mod & NSDeviceIndependentModifierFlagsMask) == NSShiftKeyMask) {
+        // S-EM really is S-Tab
+        c = '\t';
     }
     mod = NSMOD2XVIMMOD(mod);
     return [[XVimKeyStroke alloc] initWithCharacter:c modifier:(unsigned char)mod];
@@ -523,51 +537,53 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string){
 
 
 @implementation XVimKeyStroke
+@synthesize character = _character, modifier = _modifier;
+
++ (void)initialize
+{
+    init_maps();
+}
 
 - (id)initWithCharacter:(unichar)c modifier:(unsigned char)mod{
     if( self = [super init] ){
-        self.character = c;
-        self.modifier = mod;
+        _character = c;
+        _modifier = mod;
     }
     return self;
 }
 
 - (XVimString*)xvimString{
-    return MakeXVimString(self.character, self.modifier);
+    return MakeXVimString(_character, _modifier);
 }
 
 - (BOOL) isNumeric{
-    if( self.modifier == 0 && ( '0' <= self.character && self.character <= '9' ) ){
-        return YES;
-    }else{
-        return NO;
-    }
+    return _modifier == 0 && ('0' <= _character && _character <= '9');
 }
 
 - (NSUInteger)hash{
-	return self.modifier + self.character;
+    return _modifier + _character;
 }
 
 - (BOOL)isEqual:(id)object{
-	if (object == self) {
-		return YES;
-	}	
-	if (!object || ![object isKindOfClass:[self class]]){
-		return NO;
-	}
-	XVimKeyStroke* other = object;
-	return self.character == other.character && self.modifier== other.modifier;
+    if (object == self) {
+        return YES;
+    }
+    if (!object || ![object isKindOfClass:[self class]]){
+        return NO;
+    }
+    XVimKeyStroke* other = object;
+    return _character == other.character && _modifier== other.modifier;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    return [[XVimKeyStroke allocWithZone:zone] initWithCharacter:self.character modifier:self.modifier];
+    return [[XVimKeyStroke allocWithZone:zone] initWithCharacter:_character modifier:_modifier];
 }
 
 - (NSEvent*)toEventwithWindowNumber:(NSInteger)num context:(NSGraphicsContext*)context; {
-    unichar c = self.character;
+    unichar c = _character;
     NSString *characters = [NSString stringWithCharacters:&c length:1];
-    NSUInteger mflags = XVIMMOD2NSMOD(self.modifier);
-    
+    NSUInteger mflags = XVIMMOD2NSMOD(_modifier);
+
     return  [NSEvent keyEventWithType:NSKeyDown
                              location:NSMakePoint(0, 0)
                         modifierFlags:mflags
@@ -576,18 +592,18 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string){
                               context:context
                            characters:characters
           charactersIgnoringModifiers:characters
-                            isARepeat:NO 
+                            isARepeat:NO
                               keyCode:0];
 }
 
 - (NSString*)description{
     NSMutableString *str = [[NSMutableString alloc] init];
 
-    if (0 != self.modifier) {
-        [str appendFormat:@"mod{0x%02x 0x%02x} ", KS_MODIFIER, self.modifier];
+    if (0 != _modifier) {
+        [str appendFormat:@"mod{0x%02x 0x%02x} ", KS_MODIFIER, _modifier];
     }
 
-    unichar c = self.character;
+    unichar c = _character;
     if (isPrintable(c)) {
         [str appendFormat:@"code{%C} ", c];
     }else{
@@ -598,92 +614,82 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string){
     return str;
 }
 
-- (NSString*)keyNotation{
-	NSMutableString *keyStr = [[NSMutableString alloc] init];
-	unichar charcode = self.character;
+- (BOOL)isPrintable
+{
+    return !_modifier && isPrintable(_character);
+}
 
-    if (self.modifier || !isPrintable(charcode)) {
+- (NSString*)keyNotation{
+    NSMutableString *keyStr = [[NSMutableString alloc] init];
+    unichar charcode = _character;
+
+    if (_modifier || !isPrintable(charcode)) {
         [keyStr appendString:@"<"];
     }
-	
-	if (self.modifier & XVIM_MOD_SHIFT) {
-		[keyStr appendString:@"S-"];
-	}
-	if (self.modifier & XVIM_MOD_CTRL) {
-		[keyStr appendString:@"C-"];
-	}
-	if (self.modifier & XVIM_MOD_ALT) {
-		[keyStr appendString:@"M-"];
-	}
-	if (self.modifier & XVIM_MOD_CMD) {
-		[keyStr appendString:@"D-"];
-	}
-	if (self.modifier & XVIM_MOD_FUNC) {
-		[keyStr appendString:@"F-"];
-	}
+
+    if (_modifier & XVIM_MOD_SHIFT) {
+        [keyStr appendString:@"S-"];
+    }
+    if (_modifier & XVIM_MOD_CTRL) {
+        [keyStr appendString:@"C-"];
+    }
+    if (_modifier & XVIM_MOD_ALT) {
+        [keyStr appendString:@"M-"];
+    }
+    if (_modifier & XVIM_MOD_CMD) {
+        [keyStr appendString:@"D-"];
+    }
+    if (_modifier & XVIM_MOD_FUNC) {
+        [keyStr appendString:@"F-"];
+    }
 
     [keyStr appendString:keyFromUnichar(charcode)];
-	
-    if (self.modifier || !isPrintable(charcode)) {
+
+    if (_modifier || !isPrintable(charcode)) {
         [keyStr appendString:@">"];
     }
     return keyStr;
 }
 
-- (NSString*) toSelectorString {
+- (SEL)selector
+{
 	// S- Shift
 	// C- Control
 	// M- Option
 	// D- Command
     // F_ Function (not F1,F2.. but 'Function' key)
-	NSMutableString* keyStr = [[NSMutableString alloc] init];
-	if( self.modifier & XVIM_MOD_SHIFT){
-		[keyStr appendString:@"S_"];
-	}
-	if( self.modifier & XVIM_MOD_CTRL){
-		[keyStr appendString:@"C_"];
-	}
-	if( self.modifier & XVIM_MOD_ALT){
-		[keyStr appendString:@"M_"];
-	}
-	if( self.modifier & XVIM_MOD_CMD){
-		[keyStr appendString:@"D_"];
-	}
-    if( self.modifier & XVIM_MOD_FUNC){
-        [keyStr appendString:@"F_"];
+    char buf[128];
+    int pos = 0;
+
+    if (_modifier & XVIM_MOD_SHIFT) {
+        buf[pos++] = 'S'; buf[pos++] = '_';
     }
-	
-	NSString *keyname = selectorFromUnichar(self.character);
-	if (keyname) { 
-		[keyStr appendString:keyname];
-	}
-	
-	return keyStr;
-}
-
-- (SEL)selector {
-    return NSSelectorFromString([self toSelectorString]);
-}
-
-- (SEL)selectorForInstance:(id)target {
-	if( [target respondsToSelector:self.selector] ){
-        return self.selector;
-    }else{
-        return nil;
+    if (_modifier & XVIM_MOD_CTRL) {
+        buf[pos++] = 'C'; buf[pos++] = '_';
     }
-}
+    if (_modifier & XVIM_MOD_ALT) {
+        buf[pos++] = 'M'; buf[pos++] = '_';
+    }
+    if (_modifier & XVIM_MOD_CMD) {
+        buf[pos++] = 'D'; buf[pos++] = '_';
+    }
+    if (_modifier & XVIM_MOD_FUNC) {
+        buf[pos++] = 'F'; buf[pos++] = '_';
+    }
 
-- (BOOL)instanceResponds:(id)target {
-	return [self selectorForInstance:target] != nil;
-}
+    if ((_character >= 'a' && _character <= 'z') || (_character >= 'A' && _character <= 'Z')) {
+        buf[pos++] = _character;
+        buf[pos++] = '\0';
+    } else {
+        NSString *keyname = [s_unicharToSelector objectForKey:@(_character)];
 
-- (BOOL)classResponds:(Class)class{
-	return [class instancesRespondToSelector:self.selector];
-}
+        if (!keyname) {
+            return @selector(__invalid_selector_name__);
+        }
+        strcpy(buf + pos, keyname.UTF8String);
+    }
 
-- (BOOL)classImplements:(Class)class {
-	IMP imp = [class instanceMethodForSelector:self.selector];
-	return imp && imp != [[class superclass] instanceMethodForSelector:self.selector];
+    return sel_getUid(buf);
 }
 
 @end

--- a/XVim/XVimMarkSetEvaluator.m
+++ b/XVim/XVimMarkSetEvaluator.m
@@ -22,8 +22,7 @@
 }
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
-    NSString* keyStr = [keyStroke toSelectorString];
-	if ([keyStr length] != 1) {
+    if (keyStroke.modifier) {
         return [XVimEvaluator invalidEvaluator];
     }
     
@@ -33,7 +32,7 @@
     mark.column = [self.sourceView.textStorage xvim_columnOfIndex:r.location];
     mark.document = [[self.sourceView documentURL] path];
     if( nil != mark.document ){
-        [[XVim instance].marks setMark:mark forName:keyStr];
+        [[XVim instance].marks setMark:mark forName:keyStroke.xvimString];
     }
     return nil;
 }

--- a/XVim/XVimMotionEvaluator.m
+++ b/XVim/XVimMotionEvaluator.m
@@ -193,7 +193,7 @@
 }
 
 - (XVimEvaluator*)onComplete_g:(XVimGMotionEvaluator*)childEvaluator{
-    if( [childEvaluator.key.toSelectorString isEqualToString:@"SEMICOLON"] ){
+    if( childEvaluator.key.selector == @selector(SEMICOLON) ){
         XVimMark* mark = [[XVim instance].marks markForName:@"." forDocument:[self.sourceView documentURL].path];
         return [self jumpToMark:mark firstOfLine:NO];
     }else{

--- a/XVim/XVimNormalEvaluator.m
+++ b/XVim/XVimNormalEvaluator.m
@@ -168,7 +168,7 @@
 }
 
 - (XVimEvaluator*)onComplete_g:(XVimGActionEvaluator*)childEvaluator{
-    if( [childEvaluator.key.toSelectorString isEqualToString:@"SEMICOLON"] ){
+    if (childEvaluator.key.selector == @selector(SEMICOLON)) {
         XVimMark* mark = [[XVim instance].marks markForName:@"." forDocument:[self.sourceView documentURL].path];
         return [self jumpToMark:mark firstOfLine:NO];
     }else{

--- a/XVim/XVimNumericEvaluator.m
+++ b/XVim/XVimNumericEvaluator.m
@@ -8,39 +8,25 @@
 
 #import "XVimNumericEvaluator.h"
 #import "XVimKeyStroke.h"
+#import "NSString+VimHelper.h"
 
 @implementation XVimNumericEvaluator
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
-    NSString* keyStr = [keyStroke toSelectorString];
-	
     
     if (keyStroke.isNumeric) {
-        if (self.numericMode) {
-            NSString* numStr = [keyStr substringFromIndex:3];
-            NSUInteger n = (NSUInteger)[numStr integerValue]; 
-			NSUInteger newHead = self.numericArg;
-            // prevent integer overflow
-            if(newHead <= floor((NSUIntegerMax - n) / 10)){
-                newHead*=10; 
-                newHead+=n;
-                self.numericArg = newHead;
-                [self.argumentString appendString:numStr];
+        unichar     buf[4] = { 'N', 'U', 'M', keyStroke.character };
+        NSUInteger  digit  = buf[3] - '0';
+
+        if (self.numericMode || digit) {
+            NSUInteger n = self.numericMode ?  self.numericArg : 0;
+
+            self.numericMode = YES;
+            if (n <= NSUIntegerMax / 10) {
+                self.numericArg = 10 * n + digit;
+                CFStringAppendCharacters((__bridge CFMutableStringRef)self.argumentString, buf, 4);
             }
             return self;
-        }
-        else{
-            if( [keyStr isEqualToString:@"NUM0"] ){
-                // Nothing to do
-                // Maybe handled by XVimNormalEvaluator
-            }else{
-                NSString* numStr = [keyStr substringFromIndex:3];
-                NSUInteger n = (NSUInteger)[numStr integerValue]; 
-				self.numericArg = n;
-				[self.argumentString appendString:numStr];
-                self.numericMode = YES;
-                return self;
-            }
         }
     }
     

--- a/XVim/XVimRegisterEvaluator.m
+++ b/XVim/XVimRegisterEvaluator.m
@@ -25,8 +25,8 @@
 }
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
-	SEL handler = [keyStroke selectorForInstance:self];
-	if (handler){
+	SEL handler = keyStroke.selector;
+	if ([self respondsToSelector:handler]) {
 		TRACE_LOG(@"Calling SELECTOR %@", NSStringFromSelector(handler));
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -85,13 +85,15 @@
         keySelector = nil;
     }
 
-    if (nextEvaluator == self && nil == keySelector){
+    if (nextEvaluator == self && nil == keySelector) {
         if (self.oneCharMode || [self windowShouldReceive:keySelector]) {
             // Here we pass the key input to original text view.
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'
             if (self.oneCharMode || keyStroke.isPrintable) {
-                if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
+                if (!keyStroke.isPrintable) {
+                    nextEvaluator = [XVimEvaluator invalidEvaluator];
+                } else if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];
                 } else if (self.oneCharMode) {
                     nextEvaluator = nil;

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -73,18 +73,24 @@
 }
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
-    SEL keySelector = [keyStroke selectorForInstance:self];
+    XVimEvaluator *nextEvaluator = self;
+
+    SEL keySelector = keyStroke.selector;
+    if ([self respondsToSelector:keySelector]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    XVimEvaluator *nextEvaluator = keySelector ? [self performSelector:keySelector] : self;
+        nextEvaluator = [self performSelector:keySelector];
 #pragma clang diagnostic pop
+    } else {
+        keySelector = nil;
+    }
 
     if (nextEvaluator == self && nil == keySelector){
         if (self.oneCharMode || [self windowShouldReceive:keySelector]) {
             // Here we pass the key input to original text view.
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'
-            if (self.oneCharMode || (keyStroke.modifier == 0 && isPrintable(keyStroke.character))) {
+            if (self.oneCharMode || keyStroke.isPrintable) {
                 if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];
                 } else if (self.oneCharMode) {

--- a/XVim/XVimVisualEvaluator.m
+++ b/XVim/XVimVisualEvaluator.m
@@ -193,7 +193,8 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
         [self.sourceView xvim_changeSelectionMode:XVIM_VISUAL_LINE];
         return [self c];
     }
-    return [[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BLOCK_KILL_EOL];
+    [self performSelector:@selector(DOLLAR)];
+    return [[XVimInsertEvaluator alloc] initWithWindow:self.window mode:XVIM_INSERT_BLOCK_KILL];
 }
 
 - (XVimEvaluator*)C_b{
@@ -216,14 +217,13 @@ static NSString* MODE_STRINGS[] = {@"", @"-- VISUAL --", @"-- VISUAL LINE --", @
 }
 
 - (XVimEvaluator*)D{
-    if (self.sourceView.selectionMode != XVIM_VISUAL_BLOCK) {
+    if (self.sourceView.selectionMode == XVIM_VISUAL_BLOCK) {
+        [self performSelector:@selector(DOLLAR)];
+    } else {
         [self.sourceView xvim_changeSelectionMode:XVIM_VISUAL_LINE];
-        return [self d];
     }
 
-    // FIXME: doesn't work ask expected in any visual mode
-    XVimDeleteEvaluator* eval = [[XVimDeleteEvaluator alloc] initWithWindow:self.window];
-    return [eval executeOperationWithMotion:XVIM_MAKE_MOTION(MOTION_NONE, LINEWISE, MOTION_OPTION_NONE, 0)];
+    return [self d];
 }
 
 - (XVimEvaluator*)C_f{


### PR DESCRIPTION
This branch significantly reduces the amount of allocations and selectors called for each keystroke

it has also a couple of fixes:
- b_v_D/b_v_C work better
- single char mode replace with a non printable key doesn't leave you in a bad state anymore (3r<Right>) and does nothing as in vim