### PR TITLE
Add jumplist feature

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -28,6 +28,9 @@ C-d, C-f, C-e, C-u, C-b, C-y, zz, zb, zt
 ## Jumps
 C-o, C-i, gd
 
+C-i is defined as 'Editor-Structure-Re Indent' in default Xcode key bindings.
+If you want to use C-i as jump, you need to clear ^I in Xcode settings 'Xcode-Preference-Key bindings'.
+
 If you want to open the file under the cursor you can use 'gd' instead of 'gf' in XVim environment.
 
 ## Insert
@@ -144,6 +147,7 @@ The dot command ('.') is supported.
   :imap    | Maps insert mode
   :omap    | Maps operator pending mode
   :!       | Execute command with external process
+  :jumps   | Show jump list. The current position is represented as '>'.
 
 ## Filename modifier for bang
 
@@ -170,6 +174,8 @@ The dot command ('.') is supported.
   :pissue       | Invoke "jump to previous issue". ":pi" does the same.
   :ncounterpart | Invoke "jump to next counterpart". ":nc" does the same.
   :pcounterpart | Invoke "jump to previous counterpart". ":pc" does the same.
+  :njump        | Invoke "go forward". ":nj" does the same.
+  :pjump        | Invoke "go back". ":pj" does the same.
 
 ## Options
 

--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A2752F5419F3E00200D1642C /* XVimQuickFixView.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F5119F3E00200D1642C /* XVimQuickFixView.m */; };
 		A2752F5519F3E00200D1642C /* XVimTaskRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F5319F3E00200D1642C /* XVimTaskRunner.m */; };
 		A2752F5819F3E04F00D1642C /* ProcessRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F5719F3E04F00D1642C /* ProcessRunner.m */; };
+		A27EBB8719EA442000C328FB /* XVimTester+Jump.m in Sources */ = {isa = PBXBuildFile; fileRef = A27EBB8619EA442000C328FB /* XVimTester+Jump.m */; };
 		A28F422817EEDBC200A3F7AE /* Logger.m in Sources */ = {isa = PBXBuildFile; fileRef = A24782B314D6F56E003B6433 /* Logger.m */; };
 		A28F422917EEDBC200A3F7AE /* XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = A24782B814D6F56E003B6433 /* XVim.m */; };
 		A28F422A17EEDBC200A3F7AE /* XVimCommandField.m in Sources */ = {isa = PBXBuildFile; fileRef = A24782BA14D6F56E003B6433 /* XVimCommandField.m */; };
@@ -190,6 +191,7 @@
 		A2752F5619F3E04F00D1642C /* ProcessRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProcessRunner.h; path = XVim/ProcessRunner.h; sourceTree = SOURCE_ROOT; };
 		A2752F5719F3E04F00D1642C /* ProcessRunner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ProcessRunner.m; path = XVim/ProcessRunner.m; sourceTree = SOURCE_ROOT; };
 		A2771E6A179EF520003B621E /* XVimTester+Issues.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Issues.m"; path = "XVim/Test/XVimTester+Issues.m"; sourceTree = SOURCE_ROOT; };
+		A27EBB8619EA442000C328FB /* XVimTester+Jump.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Jump.m"; path = "XVim/Test/XVimTester+Jump.m"; sourceTree = SOURCE_ROOT; };
 		A28D42F314FE87AF004BC121 /* XVimGMotionEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimGMotionEvaluator.h; path = XVim/XVimGMotionEvaluator.h; sourceTree = SOURCE_ROOT; };
 		A28D42F414FE87AF004BC121 /* XVimGMotionEvaluator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimGMotionEvaluator.m; path = XVim/XVimGMotionEvaluator.m; sourceTree = SOURCE_ROOT; };
 		A28D42F614FE8E2A004BC121 /* XVimInsertEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimInsertEvaluator.h; path = XVim/XVimInsertEvaluator.h; sourceTree = SOURCE_ROOT; };
@@ -405,6 +407,7 @@
 				A2771E6A179EF520003B621E /* XVimTester+Issues.m */,
 				A24BE47417AD0D30001F797B /* XVimTester+ExCmd.m */,
 				A28D895617BFF434002709D8 /* XVimTester+Search.m */,
+				A27EBB8619EA442000C328FB /* XVimTester+Jump.m */,
 			);
 			name = Testing;
 			sourceTree = "<group>";
@@ -647,6 +650,8 @@
 				A2A8A4FF14E41C66002EA6C8 /* XVimCommandLine.m */,
 				A216F39F156560FE00AD2529 /* IDEEditorArea+XVim.h */,
 				A216F3A0156560FE00AD2529 /* IDEEditorArea+XVim.m */,
+				A257C28D156567250098CA09 /* DVTSourceTextView+XVim.h */,
+				A257C28E156567250098CA09 /* DVTSourceTextView+XVim.m */,
 				6E2B33321836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.h */,
 				6E2B33331836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.m */,
 				A25032B119F805110021C34E /* IDEWorkspaceTabController+XVim.h */,
@@ -759,6 +764,7 @@
 				A28F423317EEDBC200A3F7AE /* XVimGMotionEvaluator.m in Sources */,
 				A28F423417EEDBC200A3F7AE /* XVimInsertEvaluator.m in Sources */,
 				A28F423517EEDBC200A3F7AE /* XVimMotionEvaluator.m in Sources */,
+				A27EBB8719EA442000C328FB /* XVimTester+Jump.m in Sources */,
 				A28F423617EEDBC200A3F7AE /* XVimZEvaluator.m in Sources */,
 				A28F423717EEDBC200A3F7AE /* XVimEqualEvaluator.m in Sources */,
 				A204814F19702F3E0064BE66 /* NSObject+XVimAdditions.m in Sources */,

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -2290,9 +2290,17 @@
             break;
         case MOTION_SEARCH_FORWARD:
             end = [self.textStorage searchRegexForward:motion.regex from:self.insertionPoint count:motion.count option:motion.option].location;
+			if( end == NSNotFound && !(motion.option&SEARCH_WRAP) ){
+                NSRange range = [self xvim_currentWord:MOTION_OPTION_NONE];
+                end = range.location;
+			}
             break;
         case MOTION_SEARCH_BACKWARD:
             end = [self.textStorage searchRegexBackward:motion.regex from:self.insertionPoint count:motion.count option:motion.option].location;
+			if( end == NSNotFound && !(motion.option&SEARCH_WRAP) ){
+				NSRange range = [self xvim_currentWord:MOTION_OPTION_NONE];
+                end = range.location;
+			}
             break;
         case TEXTOBJECT_WORD:
             range = [self.textStorage currentWord:begin count:motion.count  option:motion.option];
@@ -2345,6 +2353,7 @@
             }
             break;
         case MOTION_POSITION:
+        case MOTION_POSITION_JUMP:
             end = motion.position;
             break;
     }

--- a/XVim/Test/XVimTester+Jump.m
+++ b/XVim/Test/XVimTester+Jump.m
@@ -1,0 +1,77 @@
+//
+//  XVimTester+Jump.m
+//  XVim
+//
+//  Created by pebble8888 on 2014/10/12.
+//
+//
+
+#import "XVimTester.h"
+
+@implementation XVimTester (Jump)
+- (NSArray*)jump_testcases{
+    static NSString* text1 = @"aa\n"   // 0
+                             @"bb\n"   // 3
+                             @"cc\n";  // 6
+    static NSString* text2 = @"aa\n"   // 0
+                             @"aa\n"   // 3
+                             @"aa\n"   // 6
+                             @"bb\n"   // 9
+                             @"bb\n"   // 12
+                             @"bb\n"   // 15
+                             @"cc\n"   // 18
+                             @"cc\n"   // 21
+                             @"cc\n";  // 24
+    static NSString* text3 = @"aaa bbb.\n"  // 0
+                             @"ccc ddd.\n"; // 9
+    return @[
+             XVimMakeTestCase(text1, 1,  0, @"3G``"       , text1,  1, 0), // [num]G
+             XVimMakeTestCase(text1, 1,  0, @"3G''"       , text1,  0, 0), // [num]G
+             
+             XVimMakeTestCase(text1, 1,  0, @"3G<C-o>"    , text1,  1, 0), // [num]G
+             XVimMakeTestCase(text1, 7,  0, @"gg<C-o>"    , text1,  7, 0), // gg
+             XVimMakeTestCase(text1, 1,  0, @"50%<C-o>"   , text1,  1, 0), // [num]%
+             XVimMakeTestCase(text1, 1,  0, @"G<C-o>"     , text1,  1, 0), // G
+             XVimMakeTestCase(text1, 7,  0, @"H<C-o>"     , text1,  7, 0), // H
+             XVimMakeTestCase(text1, 1,  0, @"M<C-o>"     , text1,  1, 0), // M
+             XVimMakeTestCase(text1, 1,  0, @"L<C-o>"     , text1,  1, 0), // L
+             
+             XVimMakeTestCase(text2, 1,  0, @"/aa<CR><C-o>" , text2,  1, 0), // /
+             XVimMakeTestCase(text2, 1,  0, @"/aa<CR>n<C-o>", text2,  3, 0), // n
+             XVimMakeTestCase(text2, 1,  0, @"?aa<CR><C-o>",  text2,  1, 0), // ?
+             XVimMakeTestCase(text2, 1,  0, @"?aa<CR>n<C-o>", text2,  0, 0), // n
+             
+             XVimMakeTestCase(text2, 1,  0, @"*<C-o>" ,       text2,  1, 0), // *
+             XVimMakeTestCase(text2, 1,  0, @"#<C-o>",        text2,  1, 0), // #
+             
+             XVimMakeTestCase(text3, 1,  0, @")<C-o>"       , text3,  1, 0), // )
+             XVimMakeTestCase(text3, 1,  0, @"(<C-o>"       , text3,  1, 0), // (
+             XVimMakeTestCase(text3, 1,  0, @"}<C-o>"       , text3,  1, 0), // (
+             XVimMakeTestCase(text3, 1,  0, @"{<C-o>"       , text3,  1, 0), // (
+             
+             XVimMakeTestCase(text2, 24,  0, @"ggi<ESC>jjjgi<ESC><C-o>", text2,  24, 0), // gi : gi doesn't change jump list
+             
+             XVimMakeTestCase(text1, 7,  0, @"makk`a<C-o>"  , text1,  1, 0), // `a
+             XVimMakeTestCase(text1, 7,  0, @"makk'a<C-o>"  , text1,  1, 0), // 'a
+             
+             // In original vim if 'startofline' not set, keep the same column. default value is on.
+             // In XVim 'startofline' is not supported and default value is off.
+             XVimMakeTestCase(text1, 1,  0, @"2G3G``"       , text1,  4, 0), // ``    XVim behaviour
+             //XVimMakeTestCase(text1, 1,  0, @"2G3G``"       , text1,  3, 0), // ``   original vim behaviour
+             XVimMakeTestCase(text1, 1,  0, @"2G3G````"     , text1,  7, 0), // ````  XVim behaviour
+             //XVimMakeTestCase(text1, 1,  0, @"2G3G````"     , text1,  6, 0), // ```` original vim behaviour
+             XVimMakeTestCase(text1, 1,  0, @"2G3G''"       , text1,  3, 0), // ''
+             XVimMakeTestCase(text1, 1,  0, @"2G3G''''"     , text1,  6, 0), // ''
+             
+             XVimMakeTestCase(text1, 1,  0, @"/bb<CR>/cc<CR><C-o>"            , text1,  3, 0), // <C-o>
+             XVimMakeTestCase(text1, 1,  0, @"/bb<CR>/cc<CR><C-o><C-o>"       , text1,  1, 0), // <C-o>
+             XVimMakeTestCase(text1, 1,  0, @"/bb<CR>/cc<CR><C-o><C-o>3G<C-o>", text1,  1, 0), // <C-o>
+             
+             // Re-Indent key bind need to be cleared in Xcode Preferences to pass these test.
+             XVimMakeTestCase(text1, 1,  0, @"/bb<CR>/cc<CR><C-o><C-i>"       , text1,  6, 0), // <C-i>
+             XVimMakeTestCase(text1, 1,  0, @"/bb<CR>/cc<CR><C-o><C-o><C-i><C-i>", text1,  6, 0), // <C-i>
+             
+    ];
+}
+
+@end

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -326,6 +326,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"ncounterpart", @"ncounterpart:inWindow:"),    // XVim Original
                        CMD(@"new", @"splitview:inWindow:"),
                        CMD(@"nissue", @"nissue:inWindow:"),    // XVim Original
+                       CMD(@"njump", @"njump:inWindow:"),      // XVim Original
                        CMD(@"nmap", @"nmap:inWindow:"),
                        CMD(@"nmapclear", @"nmapclear:inWindow:"),
                        CMD(@"nmenu", @"menu:inWindow:"),
@@ -358,6 +359,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"perldo", @"perldo:inWindow:"),
                        CMD(@"pedit", @"pedit:inWindow:"),
                        CMD(@"pissue", @"pissue:inWindow:"),    // XVim Original
+                       CMD(@"pjump", @"pjump:inWindow:"),      // XVim Original
                        CMD(@"pop", @"tag:inWindow:"),
                        CMD(@"popup", @"popup:inWindow:"),
                        CMD(@"ppop", @"ptag:inWindow:"),
@@ -1060,6 +1062,10 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     [window setForcusBackToSourceView];
 }
 
+- (void)njump:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [NSApp sendAction:@selector(goForwardInHistoryByCommand:) to:nil from:self];
+}
+
 - (void)nmap:(XVimExArg*)args inWindow:(XVimWindow*)window{
     if( args.arg.length == 0 ){
         [self writeMapsToConsoleWithFirstLetter:@"v" forMapMode:XVIM_MODE_NORMAL];
@@ -1121,6 +1127,10 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 - (void)pissue:(XVimExArg*)args inWindow:(XVimWindow*)window{
     [NSApp sendAction:@selector(jumpToPreviousIssue:) to:nil from:self];
     [window setForcusBackToSourceView];
+}
+
+- (void)pjump:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [NSApp sendAction:@selector(goBackInHistoryByCommand:) to:nil from:self];
 }
 
 - (void)quit:(XVimExArg*)args inWindow:(XVimWindow*)window{ // :q
@@ -1525,6 +1535,13 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 		 }
     }];
     arg.arg = resultStr;
+}
+
+- (void)jumps:(XVimExArg *)args inWindow:(XVimWindow *)window
+{
+    XVim* xvim = [XVim instance];
+    NSString* str = [xvim.marks dumpJumpList];
+    [xvim writeToConsole:str];
 }
 
 @end

--- a/XVim/XVimGActionEvaluator.m
+++ b/XVim/XVimGActionEvaluator.m
@@ -49,15 +49,8 @@
         if( NSNotFound != newPos ){
             XVimMotion* m = XVIM_MAKE_MOTION(MOTION_POSITION, CHARACTERWISE_EXCLUSIVE, MOTION_OPTION_NONE, 0);
             m.position = newPos;
-            
-            // set the position before the jump
-            XVimMark* cur_mark = [[XVimMark alloc] init];
-            cur_mark.line = [self.sourceView insertionLine];
-            cur_mark.column = [self.sourceView insertionColumn];
-            cur_mark.document = [self.sourceView documentURL].path;
-            if( nil != mark.document){
-                [[XVim instance].marks setMark:cur_mark forName:@"'"];
-            }
+			
+            [self.window preMotion:m];
             [self.sourceView xvim_move:m];
             mode = XVIM_INSERT_APPEND;
         }

--- a/XVim/XVimGMotionEvaluator.m
+++ b/XVim/XVimGMotionEvaluator.m
@@ -36,12 +36,6 @@
         return nil;
     }
     
-    // This is not for matching the searching word itself
-    // Vim also does this behavior( when matched string is not found )
-    XVimMotion* m = XVIM_MAKE_MOTION(MOTION_POSITION, CHARACTERWISE_EXCLUSIVE, MOTION_OPTION_NONE, 1);
-    m.position = r.location;
-    [self.sourceView xvim_move:m];
-    
     NSString* word = [self.sourceView.string substringWithRange:r];
     NSString* searchWord = [NSRegularExpression escapedPatternForString:word];
     [eval appendString:searchWord];

--- a/XVim/XVimMark.h
+++ b/XVim/XVimMark.h
@@ -16,6 +16,8 @@
 - (id)initWithLine:(NSUInteger)line column:(NSUInteger)col document:(NSString*)doc;
 - (id)initWithMark:(XVimMark*)mark;
 - (void)setMark:(XVimMark*)mark;
++ (id)markWithLine:(NSUInteger)line column:(NSUInteger)col document:(NSString*)doc;
++ (id)markWithMark:(XVimMark*)mark;
 @end
 
 

--- a/XVim/XVimMark.m
+++ b/XVim/XVimMark.m
@@ -47,4 +47,15 @@
     return [self initWithMark:nil];
 }
 
++ (id)markWithLine:(NSUInteger)line column:(NSUInteger)col document:(NSString*)doc{
+    return [[self alloc] initWithLine:line column:col document:doc];
+}
+
++ (id)markWithMark:(XVimMark*)mark{
+    
+    return [[self alloc] initWithMark:mark];
+}
+
+
+
 @end

--- a/XVim/XVimMarkSetEvaluator.m
+++ b/XVim/XVimMarkSetEvaluator.m
@@ -26,12 +26,8 @@
         return [XVimEvaluator invalidEvaluator];
     }
     
-    XVimMark* mark = [[XVimMark alloc] init];
-	NSRange r = [self.sourceView selectedRange];
-    mark.line = [self.sourceView.textStorage xvim_lineNumberAtIndex:r.location];
-    mark.column = [self.sourceView.textStorage xvim_columnOfIndex:r.location];
-    mark.document = [[self.sourceView documentURL] path];
-    if( nil != mark.document ){
+    XVimMark* mark = [self.window currentPositionMark];
+    if( nil != mark ){
         [[XVim instance].marks setMark:mark forName:keyStroke.xvimString];
     }
     return nil;

--- a/XVim/XVimMarks.h
+++ b/XVim/XVimMarks.h
@@ -89,4 +89,9 @@
 - (NSString*)dumpMarksForDocument:(NSString*)document;
 - (NSString*)dumpFileMarks;
 
+- (NSArray*)jumplist;
+- (NSString*)dumpJumpList;
+- (void)addToJumpListWithMark:(XVimMark*)mark KeepJumpMarkIndex:(BOOL)keepJumpMarkIndex;
+- (XVimMark*)incrementJumpMark;
+- (XVimMark*)decrementJumpMark:(BOOL*)pNeedUpdateMark;
 @end

--- a/XVim/XVimMotion.h
+++ b/XVim/XVimMotion.h
@@ -32,10 +32,10 @@ typedef enum _MOTION{
     MOTION_LINE_BACKWARD,           // j
     MOTION_END_OF_LINE,             // $
     MOTION_BEGINNING_OF_LINE,       // 0
-    MOTION_SENTENCE_FORWARD,
-    MOTION_SENTENCE_BACKWARD,
-    MOTION_PARAGRAPH_FORWARD,
-    MOTION_PARAGRAPH_BACKWARD,
+    MOTION_SENTENCE_FORWARD,        // )            jump
+    MOTION_SENTENCE_BACKWARD,       // (            jump
+    MOTION_PARAGRAPH_FORWARD,       // }            jump
+    MOTION_PARAGRAPH_BACKWARD,      // {            jump
     MOTION_NEXT_FIRST_NONBLANK,     // +
     MOTION_PREV_FIRST_NONBLANK,     // -
     MOTION_FIRST_NONBLANK,          // ^
@@ -43,15 +43,15 @@ typedef enum _MOTION{
     MOTION_PREV_CHARACTER,          // F
     MOTION_TILL_NEXT_CHARACTER,     // t
     MOTION_TILL_PREV_CHARACTER,     // T
-    MOTION_LINENUMBER,              // [num]G
-    MOTION_PERCENT,                 // [num]%
-    MOTION_NEXT_MATCHED_ITEM,       // %
-    MOTION_LASTLINE,                // G
-    MOTION_HOME,                    // H
-    MOTION_MIDDLE,                  // M
-    MOTION_BOTTOM,                  // L
-    MOTION_SEARCH_FORWARD,          // /
-    MOTION_SEARCH_BACKWARD,         // ?
+    MOTION_LINENUMBER,              // [num]G       jump
+    MOTION_PERCENT,                 // [num]%       jump
+    MOTION_NEXT_MATCHED_ITEM,       // %            jump
+    MOTION_LASTLINE,                // G            jump
+    MOTION_HOME,                    // H            jump
+    MOTION_MIDDLE,                  // M            jump
+    MOTION_BOTTOM,                  // L            jump
+    MOTION_SEARCH_FORWARD,          // /            jump
+    MOTION_SEARCH_BACKWARD,         // ?            jump
     TEXTOBJECT_WORD,
     //TEXTOBJECT_BIGWORD,           // Use motion option
     TEXTOBJECT_SENTENCE,
@@ -66,6 +66,7 @@ typedef enum _MOTION{
     TEXTOBJECT_BACKQUOTE,
     MOTION_LINE_COLUMN,             // For custom (Line,Column) position
     MOTION_POSITION,                // For custom position
+    MOTION_POSITION_JUMP,           // For custom position with jump
 }MOTION;
 
 @interface XVimMotion : NSObject
@@ -79,7 +80,10 @@ typedef enum _MOTION{
 @property unichar character;
 @property(strong) NSString* regex;
 @property XVimMotionInfo* info;
+@property BOOL jumpToAnotherFile;
+@property BOOL keepJumpMarkIndex;
 
 - (id) initWithMotion:(MOTION)motion type:(MOTION_TYPE)type option:(MOTION_OPTION)option count:(NSUInteger)count;
 - (BOOL) isTextObject;
+- (BOOL) isJumpMotion;
 @end 

--- a/XVim/XVimMotion.m
+++ b/XVim/XVimMotion.m
@@ -10,6 +10,30 @@
 
 @implementation XVimMotion
 
+- (BOOL)isJumpMotion
+{
+    switch( _motion ){
+        case MOTION_SENTENCE_FORWARD:   // )
+        case MOTION_SENTENCE_BACKWARD:  // (
+        case MOTION_PARAGRAPH_FORWARD:  // }
+        case MOTION_PARAGRAPH_BACKWARD: // {
+        case MOTION_NEXT_MATCHED_ITEM:  // %
+        case MOTION_LINENUMBER:         // [num]G
+        case MOTION_PERCENT:            // [num]%
+        case MOTION_LASTLINE:           // G
+        case MOTION_HOME:               // H
+        case MOTION_MIDDLE:             // M
+        case MOTION_BOTTOM:             // L
+        case MOTION_SEARCH_FORWARD:     // /
+        case MOTION_SEARCH_BACKWARD:    // ?
+        case MOTION_POSITION_JUMP:      // Custom position change for jump
+            return YES;
+        default:
+            break;
+    }
+    return NO;
+}
+
 - (id) initWithMotion:(MOTION)motion type:(MOTION_TYPE)type option:(MOTION_OPTION)option count:(NSUInteger)count{
     if( self = [super init]){
         _motion = motion;
@@ -23,6 +47,9 @@
         _info->isFirstWordInLine = NO;
         _info->lastEndOfLine = NSNotFound;
         _info->lastEndOfWord = NSNotFound;
+
+		_jumpToAnotherFile = NO;
+        _keepJumpMarkIndex = NO;
     }
     return self;
 }

--- a/XVim/XVimMotionEvaluator.h
+++ b/XVim/XVimMotionEvaluator.h
@@ -35,7 +35,7 @@
 // Do not override this method
 - (XVimEvaluator*)_motionFixed:(XVimMotion*)motion;
 
-- (XVimEvaluator*)jumpToMark:(XVimMark*)mark firstOfLine:(BOOL)fist;
+- (XVimEvaluator*)jumpToMark:(XVimMark*)mark firstOfLine:(BOOL)fol KeepJumpMarkIndex:(BOOL)keepJumpMarkIndex NeedUpdateMark:(BOOL)needUpdateMark;
 
 // These are only for surpress warning
 - (XVimEvaluator*)b;

--- a/XVim/XVimNormalEvaluator.m
+++ b/XVim/XVimNormalEvaluator.m
@@ -170,7 +170,7 @@
 - (XVimEvaluator*)onComplete_g:(XVimGActionEvaluator*)childEvaluator{
     if (childEvaluator.key.selector == @selector(SEMICOLON)) {
         XVimMark* mark = [[XVim instance].marks markForName:@"." forDocument:[self.sourceView documentURL].path];
-        return [self jumpToMark:mark firstOfLine:NO];
+        return [self jumpToMark:mark firstOfLine:NO KeepJumpMarkIndex:NO NeedUpdateMark:YES];
     }else{
         if( childEvaluator.motion != nil ){
             return [self _motionFixed:childEvaluator.motion];
@@ -214,12 +214,19 @@
 }
 
 - (XVimEvaluator*)C_o{
-    [NSApp sendAction:@selector(goBackInHistoryByCommand:) to:nil from:self];
+    BOOL needUpdateMark;
+    XVimMark* mark = [[XVim instance].marks decrementJumpMark:&needUpdateMark];
+    if( mark != nil ){
+        [self jumpToMark:mark firstOfLine:NO KeepJumpMarkIndex:YES NeedUpdateMark:needUpdateMark];
+    }
     return nil;
 }
 
 - (XVimEvaluator*)C_i{
-    [NSApp sendAction:@selector(goForwardInHistoryByCommand:) to:nil from:self];
+    XVimMark* mark = [[XVim instance].marks incrementJumpMark];
+    if( mark != nil ){
+        [self jumpToMark:mark firstOfLine:NO KeepJumpMarkIndex:YES NeedUpdateMark:NO];
+    }
     return nil;
 }
 
@@ -519,6 +526,7 @@
 }
 
 - (XVimEvaluator*)motionFixed:(XVimMotion *)motion{
+    [self.window preMotion:motion];
     [[self sourceView] xvim_move:motion];
     return nil;
 }

--- a/XVim/XVimVisualEvaluator.m
+++ b/XVim/XVimVisualEvaluator.m
@@ -557,6 +557,7 @@ TODO: This block is from commit 42498.
 
 - (XVimEvaluator*)motionFixed:(XVimMotion *)motion{
     if(!XVim.instance.isRepeating){
+        [self.window preMotion:motion];
         [[self sourceView] xvim_move:motion];
         [self resetNumericArg];
     }

--- a/XVim/XVimWindow.h
+++ b/XVim/XVimWindow.h
@@ -24,6 +24,7 @@
 @class IDEWorkspaceWindow;
 @class XVimEvaluatorContext;
 @class IDEEditorArea;
+@class XVimMark;
 
 @interface XVimWindow : NSObject <NSTextInputClient, NSTextFieldDelegate>
 @property(weak, readonly) NSTextView *sourceView; // This represents currently focused sourceView
@@ -50,4 +51,6 @@
 - (void)showQuickfixWithString:(NSString *)message completionHandler:(void(^)(void))completionHandler;
 - (void)closeQuickfix;
 
+- (XVimMark*)currentPositionMark;
+- (void)preMotion:(XVimMotion*)motion;
 @end


### PR DESCRIPTION
- `CTRL-i`, `CTRL-o` is changed to use jump list but Xcode forward/backward history.
- Xcode forward/backward history jump is assigned to `:njump`, `:pump`
- `jumps`
- Issue #159 and #626 relate.