### PR TITLE
Add support for Xcode 6.2 (6C131e)

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -27,6 +27,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
Fixes #707 

Add `A16FF353-8441-459E-A50C-B071F53F51B7` to the `DVTPlugInCompatibilityUUIDs` array.