### PR TITLE
Ex range command improvements

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -145,6 +145,42 @@ The dot command ('.') is supported.
   :omap    | Maps operator pending mode
   :!       | Execute command with external process
 
+## Ex ranges
+
+ Range     | Note
+-----------|-----
+  :X,Y     | Multiple line range
+  :X-N,Y   | Multiple line range
+  :X+N,Y   | Multiple line range
+  :X       | Single line range
+  :X-N     | Single line range
+  :X+N     | Single line range
+  :-N      | Single line range, shortened version of X-N where X is '.'
+  :+N      | Single line range, shortened version of X+N where X is '.'
+
+In the above table, N can only be a digit, but X and Y can be a digit, a mark reference (EXAMPLE 'a), '.', or '$'.
+
+## Ex range commands
+
+ Command   | Note
+-----------|-----
+  y[ank]   | Yank lines in range
+  d[elete] | Delete lines in range
+  copy     | Copy lines in range to new location
+  t        | Synonym for copy
+  m[ove]   | Move lines in range to new location
+  sort     | Sort lines in range
+  s[ubstitute]      | Documented in "Search and Replace" above.  '&' and '~' can be used as synonyms for 's'.
+  !        | Execute command with external process
+
+Examples:
+
+    :1,.y
+    :4,5m$
+    :'a,'bd
+    :5t10
+
+
 ## Filename modifier for bang
 
  Modifier  |

--- a/XVim/NSTextView+VimOperation.h
+++ b/XVim/NSTextView+VimOperation.h
@@ -80,8 +80,11 @@
 - (void)xvim_move:(XVimMotion*)motion;
 - (void)xvim_selectSwapEndsOnSameLine:(BOOL)onSameLine;
 - (void)xvim_delete:(XVimMotion*)motion andYank:(BOOL)yank;
+- (void)xvim_delete:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint andYank:(BOOL)yank;
 - (void)xvim_change:(XVimMotion*)motion;
 - (void)xvim_yank:(XVimMotion*)motion;
+- (void)xvim_yank:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint;
+- (void)xvim_copymove:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint withInsertionPoint:(NSUInteger)insertionPoint after:(BOOL)after onlyCopy:(BOOL)onlyCopy;
 - (void)xvim_put:(NSString*)text withType:(TEXT_TYPE)type afterCursor:(bool)after count:(NSUInteger)count;
 - (void)xvim_swapCase:(XVimMotion*)motion;
 - (void)xvim_makeLowerCase:(XVimMotion*)motion;
@@ -90,7 +93,9 @@
 - (void)xvim_join:(NSUInteger)count addSpace:(BOOL)addSpace;
 - (void)xvim_filter:(XVimMotion*)motion;
 - (void)xvim_shiftRight:(XVimMotion*)motion;
+- (void)xvim_shiftRight:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint count:(NSUInteger)count;
 - (void)xvim_shiftLeft:(XVimMotion*)motion;
+- (void)xvim_shiftLeft:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint count:(NSUInteger)count;
 - (void)xvim_insertText:(NSString*)str line:(NSUInteger)line column:(NSUInteger)column;
 - (void)xvim_insertNewlineBelowLine:(NSUInteger)line;
 - (void)xvim_insertNewlineBelowCurrentLine;

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -709,11 +709,28 @@
     [self xvim_syncState];
 }
 
+- (NSRange)_xvim_getDeleteRange:(XVimMotion*)motion withRange:(XVimRange)to{
+    NSRange r = [self xvim_getOperationRangeFrom:to.begin To:to.end Type:motion.type];
+    if( motion.type == LINEWISE && [self.textStorage isLastLine:to.end]){
+        if( r.location != 0 ){
+            motion.info->deleteLastLine = YES;
+            r.location--;
+            r.length++;
+        }
+    }
+    return r;
+}
+
 - (void)xvim_delete:(XVimMotion*)motion andYank:(BOOL)yank
+{
+    [self xvim_delete:motion withMotionPoint:self.insertionPoint andYank:yank];
+}
+
+- (void)xvim_delete:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint andYank:(BOOL)yank
 {
     NSAssert( !(self.selectionMode == XVIM_VISUAL_NONE && motion == nil),
              @"motion must be specified if current selection mode is not visual");
-    if (self.insertionPoint == 0 && [[self xvim_string] length] == 0) {
+    if (motionPoint == 0 && [[self xvim_string] length] == 0) {
         return ;
     }
     NSUInteger newPos = NSNotFound;
@@ -722,8 +739,7 @@
     
     motion.info->deleteLastLine = NO;
     if (self.selectionMode == XVIM_VISUAL_NONE) {
-        NSRange r;
-        XVimRange motionRange = [self xvim_getMotionRange:self.insertionPoint Motion:motion];
+        XVimRange motionRange = [self xvim_getMotionRange:motionPoint Motion:motion];
         if( motionRange.end == NSNotFound ){
             return;
         }
@@ -751,14 +767,7 @@
                 }
             }
         }
-        r = [self xvim_getOperationRangeFrom:motionRange.begin To:motionRange.end Type:motion.type];
-        if( motion.type == LINEWISE && [self.textStorage isLastLine:motionRange.end]){
-            if( r.location != 0 ){
-                motion.info->deleteLastLine = YES;
-                r.location--;
-                r.length++;
-            }
-        }
+        NSRange r = [self _xvim_getDeleteRange:motion withRange:motionRange];
         if (yank) {
             [self _xvim_yankRange:r withType:motion.type];
         }
@@ -768,7 +777,7 @@
             motion.motion == TEXTOBJECT_BACKQUOTE ){
             newPos = r.location;
         } else if (motion.type == LINEWISE) {
-            newPos = [self.textStorage xvim_firstNonblankInLineAtIndex:self.insertionPoint allowEOL:YES];
+            newPos = [self.textStorage xvim_firstNonblankInLineAtIndex:motionPoint allowEOL:YES];
         }
     } else if (self.selectionMode != XVIM_VISUAL_BLOCK) {
         BOOL toFirstNonBlank = (self.selectionMode == XVIM_VISUAL_LINE);
@@ -834,13 +843,29 @@
     [self xvim_syncState];
 }
 
+- (NSRange)_xvim_getYankRange:(XVimMotion*)motion withRange:(XVimRange)to{
+    NSRange r = [self xvim_getOperationRangeFrom:to.begin To:to.end Type:motion.type];
+    BOOL eof = [self.textStorage isEOF:to.end];
+    BOOL blank = [self.textStorage isBlankline:to.end];
+    if( motion.type == LINEWISE && blank && eof){
+        if( r.location != 0 ){
+            r.location--;
+            r.length++;
+        }
+    }
+    return r;
+}
+
 - (void)xvim_yank:(XVimMotion*)motion{
+    [self xvim_yank:motion withMotionPoint:self.insertionPoint];
+}
+
+- (void)xvim_yank:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint{
     NSAssert( !(self.selectionMode == XVIM_VISUAL_NONE && motion == nil), @"motion must be specified if current selection mode is not visual");
     NSUInteger newPos = NSNotFound;
 
     if( self.selectionMode == XVIM_VISUAL_NONE ){
-        NSRange r;
-        XVimRange to = [self xvim_getMotionRange:self.insertionPoint Motion:motion];
+        XVimRange to = [self xvim_getMotionRange:motionPoint Motion:motion];
         if( NSNotFound == to.end ){
             return;
         }
@@ -862,15 +887,7 @@
                 }
             }
         }
-        r = [self xvim_getOperationRangeFrom:to.begin To:to.end Type:motion.type];
-        BOOL eof = [self.textStorage isEOF:to.end];
-        BOOL blank = [self.textStorage isBlankline:to.end];
-        if( motion.type == LINEWISE && blank && eof){
-            if( r.location != 0 ){
-                r.location--;
-                r.length++;
-            }
-        }
+        NSRange r = [self _xvim_getYankRange:motion withRange:to];
         [self _xvim_yankRange:r withType:motion.type];
     } else if (self.selectionMode != XVIM_VISUAL_BLOCK) {
         NSRange range = [self _xvim_selectedRange];
@@ -888,6 +905,64 @@
     if (newPos != NSNotFound) {
         [self xvim_moveCursor:newPos preserveColumn:NO];
     }
+    [self xvim_changeSelectionMode:XVIM_VISUAL_NONE];
+}
+
+- (void)xvim_copymove:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint withInsertionPoint:(NSUInteger)insertionPoint after:(BOOL)after onlyCopy:(BOOL)onlyCopy{
+    [self xvim_registerInsertionPointForUndo];
+
+    // Handle the copy
+    XVimRange to = [self xvim_getMotionRange:motionPoint Motion:motion];
+    if( NSNotFound == to.end ){
+        return;
+    }
+    NSUInteger motionPointLine = [self.textStorage xvim_lineNumberAtIndex:motionPoint];
+    NSRange r = [self _xvim_getYankRange:motion withRange:to];
+    NSString* s = [self.xvim_string substringWithRange:r];
+
+    // Handle the paste
+    NSUInteger targetPos = insertionPoint;
+    NSUInteger targetLine = [self.textStorage xvim_lineNumberAtIndex:insertionPoint];
+    NSUInteger cursorOffset = 1;
+    // If we are pasting after any line but a blank last one, add a new line to paste into.
+    // then, the cursor will moved to this new line automatically, and we change targetPos to that
+    BOOL eof = [self.textStorage isEOF:targetPos];
+    BOOL blank = [self.textStorage isBlankline:targetPos];
+    if(after && !(eof && blank)){
+        [self xvim_insertNewlineBelowLine:targetLine];
+        targetPos = self.insertionPoint;
+        s = [s substringToIndex:s.length-1]; // Remove the last newline in the copied text, since we just added one above
+        cursorOffset = 0;
+    }
+    [self insertText:s replacementRange:NSMakeRange(targetPos,0)];
+
+    // Move the cursor to last line of what we pasted.
+    NSUInteger cursorPos = [self.textStorage xvim_firstNonblankInLineAtIndex:(targetPos+s.length-cursorOffset) allowEOL:YES];
+    [self xvim_moveCursor: cursorPos preserveColumn:NO];
+
+    // Delete the copied text if required
+    if(!onlyCopy){
+        NSUInteger cursorLine = self.insertionLine;
+        NSUInteger lineAdjustment = (cursorLine-targetLine)+(after ? 0 : 1);
+
+        // Adjust the starting line of the text to delete, if required
+        if(motionPointLine>targetLine){
+            motionPointLine += lineAdjustment;
+        }
+        // Delete the copied text
+        XVimRange to = [self xvim_getMotionRange:[self.textStorage xvim_indexOfLineNumber:motionPointLine] Motion:motion];
+        [self insertText:@"" replacementRange:[self _xvim_getDeleteRange:motion withRange:to]];
+    
+        // Adjust the line of the last line of what we pasted, if required
+        if(cursorLine>motionPointLine){ // cursorLine needs to be adjusted
+            cursorLine -= lineAdjustment+(eof && blank ? 1 : 0); // If we targeted the last blank line, increase the line adjustment to account for it
+        }
+        // Redo the move of the cursor to last line of what we pasted.
+        cursorPos = [self.textStorage xvim_firstNonblankInLineAtIndex:[self.textStorage xvim_indexOfLineNumber:cursorLine] allowEOL:YES];
+        [self xvim_moveCursor: cursorPos preserveColumn:NO];
+    }
+
+    [self xvim_syncState];
     [self xvim_changeSelectionMode:XVIM_VISUAL_NONE];
 }
 
@@ -1192,7 +1267,12 @@
 
 - (void)_xvim_shift:(XVimMotion*)motion right:(BOOL)right
 {
-    if (self.insertionPoint == 0 && [[self xvim_string] length] == 0) {
+    [self _xvim_shift:motion right:right withMotionPoint:self.insertionPoint count:1];
+}
+
+- (void)_xvim_shift:(XVimMotion*)motion right:(BOOL)right withMotionPoint:(NSUInteger)motionPoint count:(NSUInteger) count
+{
+    if (motionPoint == 0 && [[self xvim_string] length] == 0) {
         return ;
     }
 
@@ -1204,11 +1284,12 @@
     NSUndoManager *undoManager = self.undoManager;
 
     if (self.selectionMode == XVIM_VISUAL_NONE) {
-        XVimRange to = [self xvim_getMotionRange:self.insertionPoint Motion:motion];
+        XVimRange to = [self xvim_getMotionRange:motionPoint Motion:motion];
         if (to.end == NSNotFound) {
             return;
         }
         lines = XVimMakeRange([ts xvim_lineNumberAtIndex:to.begin], [ts xvim_lineNumberAtIndex:to.end]);
+        shiftWidth *= count;
     } else if (self.selectionMode != XVIM_VISUAL_BLOCK) {
         lines = [self _xvim_selectedLines];
         shiftWidth *= motion.count;
@@ -1255,8 +1336,16 @@
     [self _xvim_shift:motion right:YES];
 }
 
+- (void)xvim_shiftRight:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint count:(NSUInteger)count{
+    [self _xvim_shift:motion right:YES withMotionPoint:motionPoint count:count];
+}
+
 - (void)xvim_shiftLeft:(XVimMotion*)motion{
     [self _xvim_shift:motion right:NO];
+}
+
+- (void)xvim_shiftLeft:(XVimMotion*)motion withMotionPoint:(NSUInteger)motionPoint count:(NSUInteger)count{
+    [self _xvim_shift:motion right:NO withMotionPoint:motionPoint count:count];
 }
 
 - (void)xvim_insertText:(NSString*)str line:(NSUInteger)line column:(NSUInteger)column{

--- a/XVim/Test/XVimTester+ExCmd.m
+++ b/XVim/Test/XVimTester+ExCmd.m
@@ -29,8 +29,142 @@
                                     @"uuu\n"
                                     @"xxx\n";
     
+    static NSString* yank_result1 = @"ddd\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"\n"
+                             @"111\n";
+    
+    static NSString* shift_result1 = @"ddd\n"
+                             @"        111\n"
+                             @"        aaa\n"
+                             @"        XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n";
+    
+    static NSString* copy_result1 =
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"ddd\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n";
+    
+    static NSString* copy_result2 =
+                             @"ddd\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n";
+    
+    static NSString* delete_result1 =
+                             @"ddd\n"
+                             @"111\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n";
+    
+    static NSString* move_result1 =
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"ddd\n"
+                             @"111\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n";
+    
+    static NSString* move_result2 =
+                             @"ddd\n"
+                             @"111\n"
+                             @"uuu\n"
+                             @"\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"XXX\n"
+                             @"xxx\n";
+    
+    static NSString* move_result3 =
+                             @"ddd\n"
+                             @"XXX\n"
+                             @"xxx\n"
+                             @"uuu\n"
+                             @"111\n"
+                             @"aaa\n"
+                             @"\n"
+                             @"111\n";
+    
     return [NSArray arrayWithObjects:
             XVimMakeTestCase(text2, 0,  0, @"VG:sort<CR>", sort_result1, 0, 0),
+
+            //SHIFTS
+            // the following test cases assume that Xcode indent in the preference is 4 spaces
+            //shift right x2
+            XVimMakeTestCase(text2, 0,  0, @":2,4>><CR>", shift_result1, 12, 0),
+            //single address, shift right x2
+            XVimMakeTestCase(text2, 0,  0, @":2>><CR>:3>><CR>:4>><CR>", shift_result1, 36, 0),
+            //shift right x1, shift right x3, shift left x4 = no text change
+            XVimMakeTestCase(text2, 0,  0, @":2,4><CR>:2,4>>><CR>:2,4<<<<<CR>", text2, 4, 0),
+
+    	    //DELETE
+            XVimMakeTestCase(text2, 0,  0, @":3,5d<CR>", delete_result1, 8, 0),
+            //single line address using offset from current line via -/+
+            XVimMakeTestCase(text2, 0,  0, @":+4d<CR>:-2d<CR>:.d<CR>", delete_result1, 8, 0),
+            
+            //YANK
+            //test yank and . as cursor location
+            XVimMakeTestCase(text2, 0,  0, @"jjj:2,.y<CR>jjp", yank_result1, 24, 0),
+            //backwards range
+            XVimMakeTestCase(text2, 0,  0, @"jjj:.,2y<CR>jjp", yank_result1, 24, 0),
+            //named mark as address
+            XVimMakeTestCase(text2, 0,  0, @"jmajj:'a,.y<CR>jjp", yank_result1, 24, 0),
+            //single address
+            XVimMakeTestCase(text2, 0,  0, @"jjjjj:2yank<CR>p:3y<CR>p:4y<CR>p", yank_result1, 32, 0),
+
+            //COPY
+            //copy (t)
+            XVimMakeTestCase(text2, 0,  0, @":2,4t6<CR>", yank_result1, 32, 0),
+            //copy, before first line
+            XVimMakeTestCase(text2, 0,  0, @":4,6copy0<CR>", copy_result1, 8, 0),
+            //copy (t), after last line
+            XVimMakeTestCase(text2, 0,  0, @":4,6t$<CR>", copy_result2, 37, 0),
+            
+            //MOVE
+            //move before first line
+            XVimMakeTestCase(text2, 0,  0, @":3,5m0<CR>", move_result1, 8, 0),
+            //move after last line
+            XVimMakeTestCase(text2, 0,  0, @":3,5m$<CR>", move_result2, 25, 0),
+            //move in the middle
+            XVimMakeTestCase(text2, 0,  0, @":2,3m6<CR>", move_result3, 20, 0),
+            
+            //FAILURE TESTS
+            //move target in the middle of the source address
+            XVimMakeTestCase(text2, 0,  0, @":3,5m4<CR>", text2, 0, 0),
+            //copy target is unknown mark
+            XVimMakeTestCase(text2, 0,  0, @":3,5t's<CR>", text2, 0, 0),
+            //trailing characters in move target
+            XVimMakeTestCase(text2, 0,  0, @":3,5m6f<CR>", text2, 0, 0),
+            //trailing characters in shift
+            XVimMakeTestCase(text2, 0,  0, @":3,5>>f<CR>", text2, 0, 0),
     nil];
 }
 @end

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -137,7 +137,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"cnoremap", @"cnoremap:inWindow:"),
                        CMD(@"cnoreabbrev", @"abbreviate:inWindow:"),
                        CMD(@"cnoremenu", @"menu:inWindow:"),
-                       CMD(@"copy", @"copymove:inWindow:"),
+                       CMD(@"copy", @"copy:inWindow:"),
                        CMD(@"colder", @"qf_age:inWindow:"),
                        CMD(@"colorscheme", @"colorscheme:inWindow:"),
                        CMD(@"command", @"command:inWindow:"),
@@ -157,7 +157,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"cunabbrev", @"abbreviate:inWindow:"),
                        CMD(@"cunmenu", @"menu:inWindow:"),
                        CMD(@"cwindow", @"cwindow:inWindow:"),
-                       CMD(@"delete", @"operators:inWindow:"),
+                       CMD(@"delete", @"delete:inWindow:"),
                        CMD(@"delmarks", @"delmarks:inWindow:"),
                        CMD(@"debug", @"debug:inWindow:"),  // This currently works as XVim debug command
                        CMD(@"debuggreedy", @"debuggreedy:inWindow:"),
@@ -303,7 +303,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"lvimgrepadd", @"vimgrep:inWindow:"),
                        CMD(@"lwindow", @"cwindow:inWindow:"),
                        CMD(@"ls", @"	buflist_list:inWindow:"),
-                       CMD(@"move", @"copymove:inWindow:"),
+                       CMD(@"move", @"move:inWindow:"),
                        CMD(@"mark", @"mark:inWindow:"),
                        CMD(@"make", @"make:inWindow:"),
                        CMD(@"map", @"map:inWindow:"),
@@ -470,7 +470,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"swapname", @"swapname:inWindow:"),
                        CMD(@"syntax", @"syntax:inWindow:"),
                        CMD(@"syncbind", @"syncbind:inWindow:"),
-                       CMD(@"t", @"copymove:inWindow:"),
+                       CMD(@"t", @"copy:inWindow:"),
                        CMD(@"tNext", @"tag:inWindow:"),
                        CMD(@"tag", @"tag:inWindow:"),
                        CMD(@"tags", @"tags:inWindow:"),
@@ -562,15 +562,15 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                        CMD(@"xnoremenu", @"menu:inWindow:"),
                        CMD(@"xunmap", @"xunmap:inWindow:"),
                        CMD(@"xunmenu", @"menu:inWindow:"),
-                       CMD(@"yank", @"operators:inWindow:"),
+                       CMD(@"yank", @"yank:inWindow:"),
                        CMD(@"z", @"z:inWindow:"),
                        CMD(@"!", @"bang:inWindow:"),
                        CMD(@"#", @"print:inWindow:"),
                        CMD(@"&", @"sub:inWindow:"),
                        CMD(@"*", @"at:inWindow:"),
-                       CMD(@"<", @"operators:inWindow:"),
+                       CMD(@"<", @"shift:inWindow:"),
                        CMD(@"=", @"equal:inWindow:"),
-                       CMD(@">", @"operators:inWindow:"),
+                       CMD(@">", @"shift:inWindow:"),
                        CMD(@"@", @"at:inWindow:"),
                        CMD(@"Next", @"previous:inWindow:"),
                        CMD(@"Print", @"print:inWindow:"),
@@ -583,7 +583,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 
 
 // This method correnspons parsing part of get_address in ex_cmds.c
-- (NSUInteger)getAddress:(unichar*)parsing :(unichar**)cmdLeft inWindow:(XVimWindow*)window
+- (NSUInteger)getAddress:(unichar*)parsing :(unichar**)cmdLeft allowZero:(BOOL)allowZero inWindow:(XVimWindow*)window
 {
     NSTextView* view = [window sourceView];
     //DVTFoldingTextStorage* storage = [view textStorage];
@@ -600,7 +600,8 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     {
         case '.':
             parsing++;
-            addr = [view.textStorage xvim_lineNumberAtIndex:begin];
+            //This should be the cursor position, which is insertionPoint
+            addr = [view.textStorage xvim_lineNumberAtIndex:view.insertionPoint];
             break;
         case '$':			    /* '$' - last line */
             parsing++;
@@ -616,7 +617,11 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                 addr = [view.textStorage xvim_lineNumberAtIndex:end];
                 parsing+=2;
             }else{
-                // Other marks or invalid character. XVim does not support this.
+                XVimMark* m = [[XVim instance].marks markForName:[NSString stringWithFormat:@"%c", mark] forDocument:window.sourceView.documentURL.path];
+                if(m!=nil) {
+                    addr = m.line;
+                    parsing+=2;
+                }
             }
             break;
         case '/':
@@ -631,10 +636,17 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                 parsing++;
                 count++;
             }
-            addr = (unsigned int)[[NSString stringWithCharacters:tmp length:count] intValue];
-            if( 0 == addr ){
+    
+            // Use a conversion that returns nil, so we can tell the difference between a bad integer and 0
+            NSNumberFormatter* f = [[NSNumberFormatter alloc] init];
+            NSNumber *n = [f numberFromString:[NSString stringWithCharacters:tmp length:count]];
+            if(n==nil) {
                 addr = NSNotFound;
+            } else {
+                addr = [n unsignedIntegerValue];
             }
+            if(addr == 0 && !allowZero) // Either we change this into a 1, or we leave it as 0 if requested
+                addr = 1;
     }
     
     // Parse additional modifier for addr ( ex. $-10 means 10 line above from end of file. Parse '-10' part here )
@@ -652,7 +664,8 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
             break;
         
         if (addr == NSNotFound){
-            //addr = [view lineNumber:begin]; // This should be current cursor posotion
+            //This should be the cursor position, which is insertionPoint
+            addr = [view.textStorage xvim_lineNumberAtIndex:view.insertionPoint];
         }
         
         // Determine if its + or -
@@ -687,6 +700,17 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     return addr;
 }
 
+// Get a unichar array suitable for the parsing process
+- (unichar*)_getUnicharArray:(NSString*)cmd
+{
+    NSUInteger len = [cmd length];
+    NSMutableData* dataCmd = [NSMutableData dataWithLength:(len+1)*sizeof(unichar)];
+    unichar* pCmd = (unichar*)[dataCmd bytes];
+    [cmd getCharacters:pCmd range:NSMakeRange(0,len)];
+    pCmd[len] = 0; // NULL terminate
+    return pCmd;
+}
+
 // This method correnspons parsing part of do_one_cmd in ex_docmd.c in Vim
 // What Vim does in this function is followings
 /*
@@ -715,12 +739,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     NSUInteger len = [cmd length];
     
     // Create unichar array to parse. Its easier
-    NSMutableData* dataCmd = [NSMutableData dataWithLength:(len+1)*sizeof(unichar)];
-    unichar* pCmd = (unichar*)[dataCmd bytes];
-    [cmd getCharacters:pCmd range:NSMakeRange(0,len)];
-    pCmd[len] = 0; // NULL terminate
-     
-    unichar* parsing = pCmd;
+    unichar* parsing = [self _getUnicharArray:cmd];
     
     // 1. skip comment lines and leading space ( XVim does not handling commnet lines )
     for( NSUInteger i = 0; i < len && ( isWhitespace(*parsing) || *parsing == ':' ); i++,parsing++ );
@@ -734,7 +753,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 	
     NSTextView* view = [window sourceView];
     for(;;){
-        NSUInteger addr = [self getAddress:parsing :&parsing inWindow:window];
+        NSUInteger addr = [self getAddress:parsing :&parsing allowZero:NO inWindow:window];
         if( NSNotFound == addr ){
             if( *parsing == '%' ){ // XVim only supports %
                 exarg.lineBegin = 1;
@@ -765,12 +784,19 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
         exarg.lineBegin = [view.textStorage xvim_lineNumberAtIndex:view.insertionPoint];
         exarg.lineEnd =  exarg.lineBegin;
     }
-    
+	
+    // Swap the range, if necessary
+    if((exarg.lineBegin != NSNotFound && exarg.lineEnd != NSNotFound) && (exarg.lineBegin>exarg.lineEnd)){
+        NSUInteger tmp = exarg.lineBegin;
+        exarg.lineBegin = exarg.lineEnd;
+        exarg.lineEnd = tmp;
+    }
+
     // 4. parse command
     // In window command and its argument must be separeted by space
     unichar* tmp = parsing;
     NSUInteger count = 0;
-    if (*parsing == '!') {
+    if (*parsing == '!' || *parsing== '<' || *parsing == '>') {
         parsing++; count++;
     }
     else
@@ -1053,6 +1079,68 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
     NSTextView* view = [window sourceView];
     [view setNeedsUpdateFoundRanges:YES];
     [view xvim_clearHighlightText];
+}
+
+- (void)yank:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    if (args.lineBegin == NSNotFound && args.lineEnd == NSNotFound)
+        return;
+    NSTextView* view = [window sourceView];
+    [view xvim_yank:XVIM_MAKE_MOTION(MOTION_LINE_FORWARD, LINEWISE, MOTION_OPTION_NONE, args.lineEnd!=NSNotFound ? args.lineEnd-args.lineBegin : 1) withMotionPoint:[view.textStorage xvim_indexOfLineNumber:args.lineBegin]];
+}
+
+- (void)delete:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    if (args.lineBegin == NSNotFound && args.lineEnd == NSNotFound)
+        return;
+    NSTextView* view = [window sourceView];
+    [view xvim_delete:XVIM_MAKE_MOTION(MOTION_LINE_FORWARD, LINEWISE, MOTION_OPTION_NONE, args.lineEnd!=NSNotFound ? args.lineEnd-args.lineBegin : 1) withMotionPoint:[view.textStorage xvim_indexOfLineNumber:args.lineBegin] andYank:YES];
+}
+
+- (void)copy:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [self copymove:args onlyCopy:YES inWindow:window];
+}
+
+- (void)move:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    [self copymove:args onlyCopy:NO inWindow:window];
+}
+
+- (void)copymove:(XVimExArg*)args onlyCopy:(bool)onlyCopy inWindow:(XVimWindow*)window{
+    // If we don't have a valid copy area, or a valid paste address, return
+    if ((args.lineBegin == NSNotFound && args.lineEnd == NSNotFound) || args.arg==nil){
+        return;
+    }
+    unichar* parsing = [self _getUnicharArray:args.arg];
+    NSUInteger addr = [self getAddress:parsing :&parsing allowZero:YES inWindow:window];
+    // If there are trailing characters in the address, or the address is NotFound, return
+    if(*parsing!=0 || addr==NSNotFound){
+        return;
+    }
+    // You cannot move a range into itself.
+    if(!onlyCopy && (addr == args.lineBegin || (args.lineEnd!=NSNotFound && addr>args.lineBegin && addr<=args.lineEnd))){
+	    return;
+    }
+    NSTextView* view = [window sourceView];
+    // An address of 0 means paste BEFORE the first line
+    [view xvim_copymove:XVIM_MAKE_MOTION(MOTION_LINE_FORWARD, LINEWISE, MOTION_OPTION_NONE, args.lineEnd!=NSNotFound ? args.lineEnd-args.lineBegin : 1) withMotionPoint:[view.textStorage xvim_indexOfLineNumber:args.lineBegin] withInsertionPoint:[view.textStorage xvim_indexOfLineNumber:addr==0 ? 1 : addr] after:addr!=0 onlyCopy:onlyCopy];
+}
+
+- (void)shift:(XVimExArg*)args inWindow:(XVimWindow*)window{
+    // If we don't have a valid shift area, return
+    if (args.lineBegin == NSNotFound && args.lineEnd == NSNotFound){
+        return;
+    }
+    //if we dont use the same character as the command for the entire length of the arg, then its a mistake, return
+    if (args.arg!=nil && ![[@"" stringByPaddingToLength:args.arg.length withString:[args.cmd substringFromIndex:0] startingAtIndex:0] isEqualToString:args.arg]) {
+        return;
+    }
+    NSTextView* view = [window sourceView];
+    XVimMotion* motion = XVIM_MAKE_MOTION(MOTION_LINE_FORWARD, LINEWISE, MOTION_OPTION_NONE, args.lineEnd!=NSNotFound ? args.lineEnd-args.lineBegin : 1);
+    NSUInteger motionPoint = [view.textStorage xvim_indexOfLineNumber:args.lineBegin];
+    NSUInteger count = 1+(args.arg!=nil ? args.arg.length : 0);
+    if([args.cmd characterAtIndex:0]=='>'){
+        [view xvim_shiftRight:motion withMotionPoint:motionPoint count:count];
+    } else {
+        [view xvim_shiftLeft:motion withMotionPoint:motionPoint count:count];
+    }
 }
 
 - (void)nissue:(XVimExArg*)args inWindow:(XVimWindow*)window{


### PR DESCRIPTION
## Known Issues Fixed:
* #718 (named marks in ex range)
* #700 (ex copy feature request)

## Improvements:
1. named marks supported in ex ranges
2. swapping backwards ex range
3. change . to use insertion point instead of selection begin
4. ex yank implemented
5. ex delete implemented
6. ex copy implemented
7. ex move implemented
8. ex shift left and right implemented
9. updated Feature List with Ex range and range command information