### PR TITLE
Use relative links

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -160,7 +160,7 @@ The dot command ('.') is supported.
   :run          | Invoke Xcode's 'run' command
   :make         | Invoke Xcode's 'build' command
   :xhelp        | Show quick help for current insertion point
-  :xccmd        | (Use :xcmenucmd instead. It is simpler. ) Invoke arbitrary command in Xcode's actions in its menu. Takes one argument as its action to invoke. Actions [here](Documents/Developers/MenuActionList.txt) are available.
+  :xccmd        | (Use :xcmenucmd instead. It is simpler. ) Invoke arbitrary command in Xcode's actions in its menu. Takes one argument as its action to invoke. Actions [here](../Developers/MenuActionList.txt) are available.
   :xcmenucmd    | Invoke arbitrary command in menu. (EXAMPLE: :xcmenucmd Run)
   :nissue       | Invoke "jump to next issue". ":ni" does the same.
   :pissue       | Invoke "jump to previous issue". ":pi" does the same.

--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -160,7 +160,7 @@ The dot command ('.') is supported.
   :run          | Invoke Xcode's 'run' command
   :make         | Invoke Xcode's 'build' command
   :xhelp        | Show quick help for current insertion point
-  :xccmd        | (Use :xcmenucmd instead. It is simpler. ) Invoke arbitrary command in Xcode's actions in its menu. Takes one argument as its action to invoke. Actions [here](https://github.com/JugglerShu/XVim/blob/master/Documents/Developers/MenuActionList.txt) are available.
+  :xccmd        | (Use :xcmenucmd instead. It is simpler. ) Invoke arbitrary command in Xcode's actions in its menu. Takes one argument as its action to invoke. Actions [here](Documents/Developers/MenuActionList.txt) are available.
   :xcmenucmd    | Invoke arbitrary command in menu. (EXAMPLE: :xcmenucmd Run)
   :nissue       | Invoke "jump to next issue". ":ni" does the same.
   :pissue       | Invoke "jump to previous issue". ":pi" does the same.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/XVimProject/XVim/blob/master/README_jp.md">[日本語版]</a> 
+[\[日本語版\]](README_jp.md)
 
 # XVim [![Build Status](https://travis-ci.org/XVimProject/XVim.svg?branch=master)](https://travis-ci.org/XVimProject/XVim)
   XVim is a Vim plugin for Xcode. The plugin intends to offer a compelling Vim experience without the need to give up any Xcode features.
@@ -51,7 +51,7 @@ Delete the following directory:
     $HOME/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/XVim.xcplugin
 
 ## Feature list
-  See separate [FeatureList.md](https://github.com/XVimProject/XVim/blob/master/Documents/Users/FeatureList.md)
+  See separate [FeatureList.md](Documents/Users/FeatureList.md)
 
 ## Bug reports
   Unfortunately XVim sometimes crashes Xcode. We are working on eliminating all the bugs, but it's really hard work.
@@ -96,7 +96,7 @@ Delete the following directory:
  - [How to debug XVim](http://www.youtube.com/watch?v=AbC6f86VW9A)
  - [How to write a test case](http://www.youtube.com/watch?v=kn-kkRTtRcE)
 
-  Any pull requests are very much appreciated. Before you make a pull request see [Make a Pull Request](https://github.com/XVimProject/XVim/blob/master/Documents/Developers/PullRequest.md)
+  Any pull requests are very much appreciated. Before you make a pull request see [Make a Pull Request](Documents/Developers/PullRequest.md)
 
 ## Donations
   If you think the plugin is useful, please donate.

--- a/README_jp.md
+++ b/README_jp.md
@@ -38,7 +38,7 @@
     $HOME/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/XVim.xcplugin
 
 ## 機能一覧
-  別ファイルを参照ください。[FeatureList.md](https://github.com/JugglerShu/XVim/blob/master/Documents/Users/FeatureList.md)
+  別ファイルを参照ください。[FeatureList.md](Documents/Users/FeatureList.md)
 
 ## バグ報告
   残念ながらXVim影響でXcodeがクラッシュしてしまうことがあります。すべてのバグを取り除こうとしていますが、非常に難しいのが現状です。
@@ -81,7 +81,7 @@
  - [How to debug XVim](http://www.youtube.com/watch?v=AbC6f86VW9A)
  - [How to write a test case](http://www.youtube.com/watch?v=kn-kkRTtRcE)
 
-  Pull Requestしていただけると非常にありがたいです。Pull Requstを行う前に、[Make a Pull Request](https://github.com/JugglerShu/XVim/blob/master/Documents/Developers/PullRequest.md)
+  Pull Requestしていただけると非常にありがたいです。Pull Requstを行う前に、[Make a Pull Request](Documents/Developers/PullRequest.md)
 をご一読ください。
 
 ## 寄付


### PR DESCRIPTION
I changed the link to the relative link. Because this one is simple and is useful for a forked developer.

See also: [Relative links in READMEs - User Documentation](https://help.github.com/articles/relative-links-in-readmes/ "Relative links in READMEs - User Documentation")