### PR TITLE
Add Xcode 6.3 support to develop branch

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -28,6 +28,7 @@
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>

--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -27,6 +27,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
It seems that the Xcode 6.3 support was merged as a hotfix into `master` without merging back down to `develop`.

Thanks :cactus: 