### PR TITLE
improve :marks dump format

### DIFF
--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -1042,8 +1042,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
 - (void)marks:(XVimExArg*)args inWindow:(XVimWindow*)window{ // This is currently impelemented for debugging purpose
     NSString* local = [[XVim instance].marks dumpMarksForDocument:window.sourceView.documentURL.path];
     NSString* file = [[XVim instance].marks dumpFileMarks];
-    [[XVim instance] writeToConsole:@"----LOCAL MARKS----\n%@", local];
-    [[XVim instance] writeToConsole:@"----FILE MARKS----\n%@", file];
+    [[XVim instance] writeToConsole:@"Mark Line Column File\n%@%@", local, file];
 }
 
 - (void)ncounterpart:(XVimExArg*)args inWindow:(XVimWindow*)window{

--- a/XVim/XVimMarks.m
+++ b/XVim/XVimMarks.m
@@ -69,14 +69,15 @@ static NSString* FILE_MARKS = @"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 - (NSString*)dumpMarksForDocument:(NSString*)document{
     NSDictionary* marks = [self marksForDocument:document];
     NSMutableString* str = [[NSMutableString alloc] init];
-    [str appendString:@"Mark Line Column File\n"];
     for( NSUInteger i = 0 ; i < LOCAL_MARKS.length; i++){
         unichar c = [LOCAL_MARKS characterAtIndex:i];
         NSString* name = [NSString stringWithFormat:@"%C", c];
         XVimMark* mark = [marks objectForKey:name];
         // Here we cast NSUInteger to int to dump. This is just because it may be NSNotFound and want make it dumped as "-1" not big value.
         // This is not accurate but should not be big problem for just dumping purpose.
-        [str appendString:[[self class] markDescriptionWithName:name Mark:mark]];
+        if( mark.document != nil ){
+            [str appendString:[[self class] markDescriptionWithName:name Mark:mark]];
+        }
     }
     return str;
 }
@@ -84,14 +85,15 @@ static NSString* FILE_MARKS = @"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 - (NSString*)dumpFileMarks{
     NSDictionary* marks = _fileMarks;
     NSMutableString* str = [[NSMutableString alloc] init];
-    [str appendString:@"Mark Line Column File\n"];
     for( NSUInteger i = 0 ; i < FILE_MARKS.length; i++){
         unichar c = [FILE_MARKS characterAtIndex:i];
         NSString* name = [NSString stringWithFormat:@"%C", c];
         XVimMark* mark = [marks objectForKey:name];
         // Here we cast NSUInteger to int to dump. This is just because it may be NSNotFound and want make it dumped as "-1" not big value.
         // This is not accurate but should not be big problem for just dumping purpose.
-        [str appendString:[[self class] markDescriptionWithName:name Mark:mark]];
+        if( mark.document != nil ){
+            [str appendString:[[self class] markDescriptionWithName:name Mark:mark]];
+        }
     }
     return str;
     


### PR DESCRIPTION
This marks format is more original vim-like.
I think empty marks should not fill lines.