### PR TITLE
fix failing search test

### DIFF
--- a/XVim/Test/XVimTester+Search.m
+++ b/XVim/Test/XVimTester+Search.m
@@ -133,7 +133,7 @@
             XVimMakeTestCase(text6, 0,  0, @"Vj:s/ccc/eeeee/gc<CR>yyy", replace3_result, 28, 0),
             XVimMakeTestCase(text6, 0,  0, @":%s/ccc/eeeee/gc<CR>yyyy", replace10_result, 39, 0),
 
-            XVimMakeTestCase(text7, 0,  0, @"Vj:s/$/fffff/g<CR>", replace8_result, 15, 0),
+            XVimMakeTestCase(text7, 0,  0, @"Vj:s/$/fffff/g<CR>", replace8_result, 32, 0),
 
             // word boundaries, added to cover https://github.com/XVimProject/XVim/issues/732
             XVimMakeTestCase(text8, 0,  0, @":set vimregex<CR>:%s/\\bbbb\\b/ddd/g<CR>", replace11_result, 19, 0),


### PR DESCRIPTION
Current develop branch tests fail.

457 Passing Tests
1 Failing Tests
Result range(32,0) is different from expected range(15,0) [/develop/XVim/XVim/Test/XVimTester+Search.m:136]

Fixed it.