### PR TITLE
Add UUID to support Xcode Beta 6.4

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -29,6 +29,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
I haven't fully tested all the Xvim features in Xcode 6.4, but it didn't seem to work without adding the UUID, so I thought I would try and do that.