### PR TITLE
Add support for inverting set options

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E698B1C1B09CF7600E3F81F /* XVimTester+Options.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E698B1B1B09CF7600E3F81F /* XVimTester+Options.m */; };
 		2616859E1A3E1962007AA008 /* XVimReplaceEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = 2616859D1A3E1962007AA008 /* XVimReplaceEvaluator.m */; };
 		6E2B332D1836E42F00EFE4E2 /* XVimBuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2B332B1836E42F00EFE4E2 /* XVimBuffer.m */; };
 		6E2B33341836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E2B33331836E60600EFE4E2 /* DVTTextStorage+XVimTextStoring.m */; };
@@ -115,6 +116,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0E698B1B1B09CF7600E3F81F /* XVimTester+Options.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Options.m"; path = "XVim/Test/XVimTester+Options.m"; sourceTree = SOURCE_ROOT; };
 		2616859C1A3E1962007AA008 /* XVimReplaceEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimReplaceEvaluator.h; path = XVim/XVimReplaceEvaluator.h; sourceTree = SOURCE_ROOT; };
 		2616859D1A3E1962007AA008 /* XVimReplaceEvaluator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimReplaceEvaluator.m; path = XVim/XVimReplaceEvaluator.m; sourceTree = SOURCE_ROOT; };
 		6E2B332A1836E42F00EFE4E2 /* XVimBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XVimBuffer.h; path = XVim/XVimBuffer.h; sourceTree = SOURCE_ROOT; };
@@ -414,6 +416,7 @@
 				A24BE47417AD0D30001F797B /* XVimTester+ExCmd.m */,
 				A28D895617BFF434002709D8 /* XVimTester+Search.m */,
 				A27EBB8619EA442000C328FB /* XVimTester+Jump.m */,
+				0E698B1B1B09CF7600E3F81F /* XVimTester+Options.m */,
 			);
 			name = Testing;
 			sourceTree = "<group>";
@@ -837,6 +840,7 @@
 				A28F426917EEDBC200A3F7AE /* XVimRecordingEvaluator.m in Sources */,
 				A28F426A17EEDBC200A3F7AE /* XVimTester+Recording.m in Sources */,
 				A28F426B17EEDBC200A3F7AE /* XVimTester+Issues.m in Sources */,
+				0E698B1C1B09CF7600E3F81F /* XVimTester+Options.m in Sources */,
 				2616859E1A3E1962007AA008 /* XVimReplaceEvaluator.m in Sources */,
 				A28F426C17EEDBC200A3F7AE /* NSTextStorage+VimOperation.m in Sources */,
 				A28F426D17EEDBC200A3F7AE /* NSTextView+VimOperation.m in Sources */,

--- a/XVim/Test/XVimTester+Options.m
+++ b/XVim/Test/XVimTester+Options.m
@@ -1,0 +1,32 @@
+//
+//  XVimTester+Options.m
+//  XVim
+//
+//  Created by Paul Williamson on 18/05/2015.
+//
+//
+
+#import "XVimTester.h"
+
+@implementation XVimTester (Options)
+
+- (NSArray *)options_testcases{
+    static NSString* text1 = @"aaa BBB ccc";
+
+    return [NSArray arrayWithObjects:
+            // make sure ignore case is off
+            XVimMakeTestCase(text1, 0, 0, @":set noignorecase<CR>", text1, 0, 0),
+            // search should fail
+            XVimMakeTestCase(text1, 0, 0, @"/bbb<CR>", text1, 0, 0),
+            // toggle ignore case
+            XVimMakeTestCase(text1, 0, 0, @":set ignorecase!<CR>", text1, 0, 0),
+            // search should succeed
+            XVimMakeTestCase(text1, 0, 0, @"/bbb<CR>", text1, 4, 0), // shouldnt this be 4,3 range?
+            // toggle ignore case
+            XVimMakeTestCase(text1, 0, 0, @":set ignorecase!<CR>", text1, 0, 0),
+            // search should fail again
+            XVimMakeTestCase(text1, 0, 0, @"/bbb<CR>", text1, 0, 0),
+            nil];
+}
+
+@end

--- a/XVim/Test/XVimTester+Options.m
+++ b/XVim/Test/XVimTester+Options.m
@@ -26,6 +26,8 @@
             XVimMakeTestCase(text1, 0, 0, @":set ignorecase!<CR>", text1, 0, 0),
             // search should fail again
             XVimMakeTestCase(text1, 0, 0, @"/bbb<CR>", text1, 0, 0),
+            // make sure string inverting doesn't crash Xcode
+            XVimMakeTestCase(text1, 0, 0, @":set guioptions! rb", text1, 0, 0),
             nil];
 }
 

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -77,6 +77,12 @@
 }
 
 - (void)setOption:(NSString*)name value:(id)value{
+    BOOL toggle = NO;
+    NSRange range = [name rangeOfString:@"!"];
+    if (range.location == name.length - 1 && name.length > 1) {
+        toggle = YES;
+        name = [name substringToIndex:name.length - 1];
+    }
     NSString* propName = name;
     if( [_option_maps objectForKey:name] ){
         // If the name is abbriviation use full name
@@ -84,6 +90,16 @@
     }
     
     if( [self respondsToSelector:NSSelectorFromString(propName)] ){
+        
+        if (toggle) {
+            id oldValue = [self valueForKey:propName];
+            
+            if (strcmp([oldValue objCType], @encode(BOOL)) == 0) {
+                [self setValue:@(![oldValue boolValue]) forKey:propName];
+                return;
+            }
+        }
+        
         [self setValue:value forKey:propName];
     }
 }

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -79,7 +79,7 @@
 - (void)setOption:(NSString*)name value:(id)value{
     BOOL toggle = NO;
     NSRange range = [name rangeOfString:@"!"];
-    if (range.location == name.length - 1 && name.length > 1) {
+    if( range.location == name.length - 1 && name.length > 1 ){
         toggle = YES;
         name = [name substringToIndex:name.length - 1];
     }
@@ -90,16 +90,14 @@
     }
     
     if( [self respondsToSelector:NSSelectorFromString(propName)] ){
-        
-        if (toggle) {
+        if( toggle ){
             id oldValue = [self valueForKey:propName];
-            
-            if (strcmp([oldValue objCType], @encode(BOOL)) == 0) {
+            // Check if the old value was a BOOL
+            if( strcmp([oldValue objCType], @encode(BOOL)) == 0 ){
                 [self setValue:@(![oldValue boolValue]) forKey:propName];
                 return;
             }
         }
-        
         [self setValue:value forKey:propName];
     }
 }


### PR DESCRIPTION
This patch adds support for inverting set options. For example, in vim, you may use:

    :set rnu!

to toggle between `:set relativenumber` and `:set norelativenumber`.

I don't see a test case for options so I can't write a test case. I can confirm the following manual tests:

    :set rn!               # sets relative number on
    :set rn!               # sets relative number off
    :set relativenumber!   # sets relative number on
    :set relativenumber!   # sets relative number off
    :set bc!               # sets blinking cursor on
    :set bc!               # sets blinking cursor off
    :set clipboard!        # does nothing as `_clipboard` is not a `BOOL`
    :set !                 # does nothing
