### PR TITLE
Add startofline option (fixes gg in visual mode)

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -190,6 +190,7 @@ The dot command ('.') is supported.
   [no]relativenumber |
   [no]alwaysuseinputsource | With this option all the input is first sent to input source of the system. If you are using France, Portugese or Swedish keyboard consider turning this on. When enabling this, also consider running `defaults write com.apple.dt.Xcode ApplePressAndHoldEnabled -bool false` to disable the press and hold character menu in recent OS X releases.  (See issue https://github.com/JugglerShu/XVim/issues/598).
   [no]blinkcursor |
+  [no]startofline | Tells XVim to move the cursor to the first non-blank of the line when using jump commands (`gg, G` etc). Defaults to on.
 
 
 ## guioptions

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -24,6 +24,7 @@
 #import "NSTextStorage+VimOperation.h"
 #import "Logger.h"
 #import "XVimMacros.h"
+#import "XVimOptions.h"
 
 #define LOG_STATE() TRACE_LOG(@"mode:%d length:%d cursor:%d ip:%d begin:%d line:%d column:%d preservedColumn:%d", \
                             self.selectionMode,            \
@@ -647,6 +648,11 @@
                 // TODO: Preserve column option can be included in motion object
                 if (self.selectionMode == XVIM_VISUAL_BLOCK && self.selectionToEOL) {
                     r.end = [self.textStorage xvim_endOfLine:r.end];
+                } else if (XVim.instance.options.startofline) {
+                    // only jump to nonblank line for last line or line number
+                    if (motion.motion == MOTION_LASTLINE || motion.motion == MOTION_LINENUMBER) {
+                        r.end = [self.textStorage xvim_firstNonblankInLineAtIndex:r.end allowEOL:NO];
+                    }
                 }
                 [self xvim_moveCursor:r.end preserveColumn:YES];
                 break;

--- a/XVim/Test/XVimTester+Jump.m
+++ b/XVim/Test/XVimTester+Jump.m
@@ -55,11 +55,14 @@
              XVimMakeTestCase(text1, 7,  0, @"makk'a<C-o>"  , text1,  1, 0), // 'a
              
              // In original vim if 'startofline' not set, keep the same column. default value is on.
-             // In XVim 'startofline' is not supported and default value is off.
+             XVimMakeTestCase(text1, 0, 0, @":set nostartofline<CR>", text1, 0, 0),
              XVimMakeTestCase(text1, 1,  0, @"2G3G``"       , text1,  4, 0), // ``    XVim behaviour
-             //XVimMakeTestCase(text1, 1,  0, @"2G3G``"       , text1,  3, 0), // ``   original vim behaviour
              XVimMakeTestCase(text1, 1,  0, @"2G3G````"     , text1,  7, 0), // ````  XVim behaviour
-             //XVimMakeTestCase(text1, 1,  0, @"2G3G````"     , text1,  6, 0), // ```` original vim behaviour
+
+             XVimMakeTestCase(text1, 0, 0, @":set startofline<CR>", text1, 0, 0),
+             XVimMakeTestCase(text1, 1,  0, @"2G3G``"       , text1,  3, 0), // ``   original vim behaviour
+             XVimMakeTestCase(text1, 1,  0, @"2G3G````"     , text1,  6, 0), // ```` original vim behaviour
+
              XVimMakeTestCase(text1, 1,  0, @"2G3G''"       , text1,  3, 0), // ''
              XVimMakeTestCase(text1, 1,  0, @"2G3G''''"     , text1,  6, 0), // ''
              

--- a/XVim/Test/XVimTester+Motion.m
+++ b/XVim/Test/XVimTester+Motion.m
@@ -57,12 +57,12 @@
             XVimMakeTestCase(text2, 24, 0, @"4fi", text2, 24, 0), // error case
             
             // g, G
-            XVimMakeTestCase(text2, 44, 0,  @"gg", text2,  8, 0),
-            XVimMakeTestCase(text2, 44, 0, @"3gg", text2, 32, 0),
-            XVimMakeTestCase(text2,  8, 0, @"9gg", text2, 44, 0),
+            XVimMakeTestCase(text2, 44, 0,  @"gg", text2,  0, 0),
+            XVimMakeTestCase(text2, 44, 0, @"3gg", text2, 24, 0),
+            XVimMakeTestCase(text2,  8, 0, @"9gg", text2, 40, 0),
             XVimMakeTestCase(text2,  4, 0,   @"G", text2, 40, 0),
-            XVimMakeTestCase(text2, 44, 0,  @"3G", text2, 32, 0),
-            XVimMakeTestCase(text2,  8, 0,  @"9G", text2, 44, 0),
+            XVimMakeTestCase(text2, 44, 0,  @"3G", text2, 24, 0),
+            XVimMakeTestCase(text2,  8, 0,  @"9G", text2, 40, 0),
             
             // h,j,k,l, <space>
             XVimMakeTestCase(text1, 0, 0,   @"l", text1, 1, 0),

--- a/XVim/Test/XVimTester+Visual.m
+++ b/XVim/Test/XVimTester+Visual.m
@@ -138,7 +138,7 @@
             XVimMakeTestCase(text1, 0,  0, @"vllcxxx<ESC>", vllccxxx_result, 2, 0),
             XVimMakeTestCase(text2, 0,  0, @"vlljgU", vgU_result , 0, 0), // vgU
             XVimMakeTestCase(text2, 14,  0, @"vggU",  vgU_result , 0, 0), // vggU (same result with gU)
-            XVimMakeTestCase(text2, 12,  0, @"vGU",  vGU_result, 0, 0),  // vGU
+            XVimMakeTestCase(text2, 12,  0, @"vGU",  vGU_result, 12, 0),  // vGU
             XVimMakeTestCase(text2, 0,  0, @"vlljU",  vgU_result , 0, 0), // vU (same result with gU)
             XVimMakeTestCase(text2, 12,  0, @"VggU", VgU_result, 0, 0),  // VggU
             XVimMakeTestCase(text2, 0,  0, @"VlljgU", VgU_result, 0, 0),  // VgU

--- a/XVim/Test/XVimTester+Visual.m
+++ b/XVim/Test/XVimTester+Visual.m
@@ -77,6 +77,16 @@
                                   @"ggg hhh i_i\n"  // 24 28 32
                                   @"    jjj kkk";   // 36 40 44
     
+    static NSString* VGU_result=  @"a;a bbb ccc\n"  // 0  4  8
+                                  @"DDD E-E FFF\n"  // 12 16 20
+                                  @"GGG HHH I_I\n"  // 24 28 32
+                                  @"    JJJ KKK";   // 36 40 44
+
+    static NSString* vGU_result=  @"a;a bbb ccc\n"  // 0  4  8
+                                  @"DDD E-E FFF\n"  // 12 16 20
+                                  @"GGG HHH I_I\n"  // 24 28 32
+                                  @"    Jjj kkk";   // 36 40 44
+    
     static NSString* c_vgU_result=  @"A;A bbb ccc\n"  // 0  4  8
                                     @"DDD e-e fff\n"  // 12 16 20
                                     @"ggg hhh i_i\n"  // 24 28 32
@@ -127,9 +137,13 @@
             XVimMakeTestCase(text2, 0,  0, @"<C-v>lljjd", C_v_d_result, 0, 0),
             XVimMakeTestCase(text1, 0,  0, @"vllcxxx<ESC>", vllccxxx_result, 2, 0),
             XVimMakeTestCase(text2, 0,  0, @"vlljgU", vgU_result , 0, 0), // vgU
+            XVimMakeTestCase(text2, 14,  0, @"vggU",  vgU_result , 0, 0), // vggU (same result with gU)
+            XVimMakeTestCase(text2, 12,  0, @"vGU",  vGU_result, 0, 0),  // vGU
             XVimMakeTestCase(text2, 0,  0, @"vlljU",  vgU_result , 0, 0), // vU (same result with gU)
+            XVimMakeTestCase(text2, 12,  0, @"VggU", VgU_result, 0, 0),  // VggU
             XVimMakeTestCase(text2, 0,  0, @"VlljgU", VgU_result, 0, 0),  // VgU
             XVimMakeTestCase(text2, 0,  0, @"VlljU",  VgU_result, 0, 0),  // VU
+            XVimMakeTestCase(text2, 12,  0, @"VGU",  VGU_result, 12, 0),  // VGU
             XVimMakeTestCase(text2, 0,  0, @"<C-v>lljgU", c_vgU_result, 0, 0), // <C-v>gU
             XVimMakeTestCase(text2, 0,  0, @"<C-v>lljU", c_vgU_result, 0, 0), // <C-v>U
             

--- a/XVim/XVimOptions.h
+++ b/XVim/XVimOptions.h
@@ -26,6 +26,7 @@
 @property BOOL relativenumber;
 @property BOOL alwaysuseinputsource; //XVim original
 @property BOOL blinkcursor;
+@property BOOL startofline;
 
 - (id)getOption:(NSString*)name;
 - (void)setOption:(NSString*)name value:(id)value;

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -39,6 +39,7 @@
          @"relativenumber", @"rn",
          @"alwaysuseinputsource", @"auis",
          @"blinkcursor", @"bc",
+         @"startofline", @"sol",
          nil];
         
         // Default values
@@ -58,6 +59,7 @@
         _relativenumber = NO;
         _alwaysuseinputsource = NO;
         _blinkcursor = NO;
+        _startofline = YES;
     }
     return self;
 }


### PR DESCRIPTION
This patch adds a `startofline` option to `XVimOptions`. This option follows vim, where it is `on` by default.

When `startofline` is set, whenever `G` or `gg` is used, the cursor will be placed on the first non-blank character of the last or first line respectively.

When `nostartofline` is set, the current cursor column will be preserved.

This patch fixes #742 and is made possible by a patch from @J-Fields

--------

As this patch changes default behaviour, some of the existing tests have been amended to reflect the **correct** intended behaviour. Tests for `set startofline` and `set nostartofline` have been added to `XVimTester+Jump.m`.