### PR TITLE
Add support for Xcode 6.3.2

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -29,6 +29,7 @@
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
Xcode 6.3.2 requires a new plug-in compatibility UUID (`E969541F-E6F9-4D25-8158-72DC3545A6C6`).