### PR TITLE
Improvement Genius mode and comparison mode

### DIFF
--- a/XVim/IDEWorkspaceTabController+XVim.h
+++ b/XVim/IDEWorkspaceTabController+XVim.h
@@ -8,6 +8,12 @@
 
 #import "IDEKit.h"
 
+typedef NS_ENUM(NSInteger,EditorMode) {
+    STANDARD,
+    GENIUS,
+    VERSION
+};
+
 @interface IDEWorkspaceTabController (XVim)
 - (void)xvim_jumpFocus:(NSInteger)count relative:(BOOL)relative;
 - (void)xvim_addEditor;

--- a/XVim/IDEWorkspaceTabController+XVim.m
+++ b/XVim/IDEWorkspaceTabController+XVim.m
@@ -139,6 +139,8 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
         count = MIN(ABS(count), numEditors) - 1; // -1 to convert it to array index
         [allEditors[(NSUInteger)(count%numEditors)] takeFocus];
     }
+    // redraw caret
+    [current.view setNeedsDisplay:YES];
 }
 
 - (void)xvim_addEditor{
@@ -185,7 +187,8 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
         }
     }
     [targetEditor takeFocus];
-    
+    // redraw caret
+    [current.view setNeedsDisplay:YES];
 }
 
 - (void)xvim_moveFocusUp{
@@ -211,7 +214,8 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
         }
     }
     [targetEditor takeFocus];
-    
+    // redraw caret
+    [current.view setNeedsDisplay:YES];
 }
 
 - (void)xvim_moveFocusLeft{
@@ -236,6 +240,8 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
         }
     }
     [targetEditor takeFocus];
+    // redraw caret
+	[current.view setNeedsDisplay:YES];
 }
 
 - (void)xvim_moveFocusRight{
@@ -259,6 +265,8 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
         }
     }
     [targetEditor takeFocus];
+    // redraw caret
+	[current.view setNeedsDisplay:YES];
 }
 
 - (void)xvim_closeOtherEditors{

--- a/XVim/XVimWindow.m
+++ b/XVim/XVimWindow.m
@@ -23,6 +23,7 @@
 #import "DVTSourceTextView+XVim.h"
 #import "XVimMark.h"
 #import "XVimMarks.h"
+#import "IDEWorkspaceTabController+XVim.h"
 
 @interface XVimWindow () {
     NSMutableArray     *_defaultEvaluatorStack;
@@ -72,7 +73,7 @@
         return obj;
     }
 
-    if (_editorArea.editorMode == 2 && [editor isKindOfClass:[IDEComparisonEditor class]]) {
+    if (_editorArea.editorMode == VERSION && [editor isKindOfClass:[IDEComparisonEditor class]]) {
         obj = [[(IDEComparisonEditor *)editor keyEditor] mainScrollView].documentView;
         return obj;
     }


### PR DESCRIPTION
- Bug fix #711 caret isn't  redrawn in genius mode.

- Improvement for comparison mode.

In version comparison mode when you change window focus the current cursor line number is preserved like the original vimdiff mode.