### PR TITLE
Add support swift format module header for bang

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A204814F19702F3E0064BE66 /* NSObject+XVimAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A204814E19702F3E0064BE66 /* NSObject+XVimAdditions.m */; };
 		A212A53D1940A330002FB2CF /* XVim.xcplugin in Copy Files */ = {isa = PBXBuildFile; fileRef = A2E7E45217EF0219008F045A /* XVim.xcplugin */; };
 		A25032B319F805110021C34E /* IDEWorkspaceTabController+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = A25032B219F805110021C34E /* IDEWorkspaceTabController+XVim.m */; };
+		A259E2231B3C263B006000D9 /* NSURL+XVimXcodeModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A259E2221B3C263B006000D9 /* NSURL+XVimXcodeModule.m */; };
 		A2752F4F19F3DFAD00D1642C /* NSAttributedString+Geometrics.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F4E19F3DFAD00D1642C /* NSAttributedString+Geometrics.m */; };
 		A2752F5419F3E00200D1642C /* XVimQuickFixView.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F5119F3E00200D1642C /* XVimQuickFixView.m */; };
 		A2752F5519F3E00200D1642C /* XVimTaskRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = A2752F5319F3E00200D1642C /* XVimTaskRunner.m */; };
@@ -176,6 +177,8 @@
 		A2575405172F65E6003D8A97 /* XVimTester+Operator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Operator.m"; path = "XVim/Test/XVimTester+Operator.m"; sourceTree = SOURCE_ROOT; };
 		A2575408172F6698003D8A97 /* XVimTester+Mark.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Mark.m"; path = "XVim/Test/XVimTester+Mark.m"; sourceTree = SOURCE_ROOT; };
 		A257540B1732A58E003D8A97 /* XVimTester+Visual.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XVimTester+Visual.m"; path = "XVim/Test/XVimTester+Visual.m"; sourceTree = SOURCE_ROOT; };
+		A259E2211B3C263B006000D9 /* NSURL+XVimXcodeModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+XVimXcodeModule.h"; path = "XVim/NSURL+XVimXcodeModule.h"; sourceTree = SOURCE_ROOT; };
+		A259E2221B3C263B006000D9 /* NSURL+XVimXcodeModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURL+XVimXcodeModule.m"; path = "XVim/NSURL+XVimXcodeModule.m"; sourceTree = SOURCE_ROOT; };
 		A2640CC717ACE651003D197D /* NSTextView+VimOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSTextView+VimOperation.h"; path = "XVim/NSTextView+VimOperation.h"; sourceTree = SOURCE_ROOT; };
 		A2640CC817ACE651003D197D /* NSTextView+VimOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSTextView+VimOperation.m"; path = "XVim/NSTextView+VimOperation.m"; sourceTree = SOURCE_ROOT; };
 		A26ACC4C154F2D6600B27D69 /* IDEEditor+XVim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "IDEEditor+XVim.h"; path = "XVim/IDEEditor+XVim.h"; sourceTree = SOURCE_ROOT; };
@@ -628,6 +631,8 @@
 				A2752F5719F3E04F00D1642C /* ProcessRunner.m */,
 				A2B0708519C5E9E30087CA0B /* XVimEval.h */,
 				A2B0708619C5E9E30087CA0B /* XVimEval.m */,
+				A259E2211B3C263B006000D9 /* NSURL+XVimXcodeModule.h */,
+				A259E2221B3C263B006000D9 /* NSURL+XVimXcodeModule.m */,
 			);
 			name = "XCode Independent Classes";
 			sourceTree = "<group>";
@@ -792,6 +797,7 @@
 				A28F423D17EEDBC200A3F7AE /* IDESourceCodeEditor+XVim.m in Sources */,
 				A28F423E17EEDBC200A3F7AE /* XVimNumericEvaluator.m in Sources */,
 				A28F423F17EEDBC200A3F7AE /* XVimKeymap.m in Sources */,
+				A259E2231B3C263B006000D9 /* NSURL+XVimXcodeModule.m in Sources */,
 				A28F424017EEDBC200A3F7AE /* XVimExCommand.m in Sources */,
 				A28F424117EEDBC200A3F7AE /* XVimSearch.m in Sources */,
 				A28F424217EEDBC200A3F7AE /* XVimOptions.m in Sources */,

--- a/XVim/NSURL+XVimXcodeModule.h
+++ b/XVim/NSURL+XVimXcodeModule.h
@@ -10,4 +10,8 @@
 
 @interface NSURL (XVimXcodeModule)
 - (BOOL)isXcodeModuleSchemeURL;
+- (NSString*)xcode_language;
+- (NSString*)xcode_source_header;
+- (NSString*)xcode_swift_sdk;
+- (NSString*)xcode_swift_target;
 @end

--- a/XVim/NSURL+XVimXcodeModule.h
+++ b/XVim/NSURL+XVimXcodeModule.h
@@ -1,0 +1,13 @@
+//
+//  NSURL+XVimXcodeModule.h
+//  XVim
+//
+//  Created by pebble8888 on 2015/06/25.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURL (XVimXcodeModule)
+- (BOOL)isXcodeModuleSchemeURL;
+@end

--- a/XVim/NSURL+XVimXcodeModule.m
+++ b/XVim/NSURL+XVimXcodeModule.m
@@ -13,4 +13,37 @@
     return [self.scheme isEqualToString:@"x-xcode-module"];
 }
 
+- (NSString*)xcode_language
+{
+    return self.queryString[@"language"];
+}
+
+- (NSString*)xcode_source_header
+{
+    return self.queryString[@"source-header"];
+}
+
+- (NSString*)xcode_swift_sdk
+{
+    return self.queryString[@"swift-sdk"];
+}
+
+- (NSString*)xcode_swift_target
+{
+    return self.queryString[@"swift-target"];
+}
+
+- (NSDictionary*)queryString
+{
+    NSMutableDictionary *queryStringDictionary = [NSMutableDictionary dictionary];
+    NSArray *urlComponents = [self.absoluteString componentsSeparatedByString:@"&"];
+    for (NSString *keyValuePair in urlComponents) {
+        NSArray *pairComponents = [keyValuePair componentsSeparatedByString:@"="];
+        NSString *key = [[pairComponents firstObject] stringByRemovingPercentEncoding];
+        NSString *value = [[pairComponents lastObject] stringByRemovingPercentEncoding];
+        [queryStringDictionary setObject:value forKey:key];
+    }
+    return queryStringDictionary;
+}
+
 @end

--- a/XVim/NSURL+XVimXcodeModule.m
+++ b/XVim/NSURL+XVimXcodeModule.m
@@ -1,0 +1,16 @@
+//
+//  NSURL+XVimXcodeModule.m
+//
+//  Created by pebble8888 on 2015/06/25.
+//
+//
+
+#import "NSURL+XVimXcodeModule.h"
+
+@implementation NSURL (XVimXcodeModule)
+- (BOOL)isXcodeModuleSchemeURL;
+{
+    return [self.scheme isEqualToString:@"x-xcode-module"];
+}
+
+@end

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -28,6 +28,7 @@
 #import "XVimKeymap.h"
 #import "XVimUtil.h"
 #import "XVimTester.h"
+#import "NSURL+XVimXcodeModule.h"
 
 @implementation XVimExArg
 @synthesize arg,cmd,forceit,noRangeSpecified,lineBegin,lineEnd,addr_count;
@@ -1495,6 +1496,21 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
                                           , documentPath ?             documentPath : @"", @"%"
                                           , nil];
         [ self _expandSpecialExTokens:args contextDict:contextForExCmd];
+    }
+    else if( [documentURL isXcodeModuleSchemeURL] ){
+        // Xcode convert Objective-C Framework header to swift format.
+        // We use converted text as is.
+        NSFileManager* fm = [NSFileManager defaultManager];
+        NSString* swiftpath = [NSHomeDirectory() stringByAppendingPathComponent:@".xvimtmp.swift"];
+        NSString* str = window.sourceView.string;
+        if( str.length > 0 ){
+            NSData* data = [NSData dataWithBytes:(void*)str.UTF8String length:str.length];
+            [fm createFileAtPath:swiftpath contents:data attributes:nil];
+            
+            NSDictionary* contextForExCmd = @{@"#": @"",
+                                              @"%": swiftpath ? swiftpath: @""};
+            [self _expandSpecialExTokens:args contextDict:contextForExCmd];
+        }
     }
 
     NSString* scriptReturn = [ XVimTaskRunner runScript:args.arg


### PR DESCRIPTION
Apple framework like Foundation.framework has Objective-C header file.
When I select class name like 'NSObject' and click 'Jump to Definition' 
Xcode6 show swift file that is converted from Objective-C header file probably.
So I can't open the swift file with the external editor like the MacVim.
This PR make it possible.

While a converted swift file is showed, document URL has 'x-xcode-module' scheme and original Objective-C header file path.
Because I don't know how to convert Objective-C header file to swift header file
I use showing text as is.
I have knowed them by observing Xcode behaviour that is reverse engineeing. 
No documents.  

In bang command while 'x-xcode-module' scheme file is showed,  percent is expanded to 
~/.xvimtmp.swift file. So you can open converted swift module file with it.