### PR TITLE
Fix behavior of NUMBER/searchCurrentWordForward (#723)

### DIFF
--- a/XVim/Test/XVimTester+Search.m
+++ b/XVim/Test/XVimTester+Search.m
@@ -164,6 +164,9 @@
             
             // # must not match the searched word itself
             XVimMakeTestCase(text2, 29,  0, @"#" , text2, 4, 0),
+
+            // # must not skip a match when starting at beginning of word
+            XVimMakeTestCase(text2,44,  0, @"#" , text2, 28, 0),
             
             // Search with * or # must be saved in search history
             XVimMakeTestCase(text2, 5,  0, @"*/<UP><CR>" , text2, 44, 0),

--- a/XVim/XVimMotionEvaluator.m
+++ b/XVim/XVimMotionEvaluator.m
@@ -337,7 +337,13 @@
     [eval execute];
     XVimMotion* motion = eval.evalutionResult;
     if( !forward ){
-        ++motion.count;
+        // NB when searching backward (`QUESTION`) while in the middle of the
+        // searched word, the first match is the word at the cursor. Therefore,
+        // search backwards an extra time if not at the beginning of a word.
+        NSUInteger index = self.sourceView.insertionPoint;
+        if( isKeyword([self.sourceView.xvim_string characterAtIndex:(index - 1)]) ){
+            ++motion.count;
+        }
     }
     [self _motionFixed:motion];
     return nil;


### PR DESCRIPTION
Only search backwards an extra time if not at the beginning of a word.

The method `searchCurrentWordForward` when parameter `forward` is `NO`
previously skipped a word if the cursor is at the beginning of a word.
Repeatedly invoking `NUMBER` would skip every other word. NB when
searching backward (`QUESTION`) while in the middle of the searched
word, the first match is the word at the cursor. This was incorrectly
compensated for by searching backwards an extra time, regardless of
cursor location in the current word.

- The new test case fails without the fix, and succeeds with the fix.
- Maybe fixes issue #723.