### PR TITLE
Implement noexpandtab for `>>`, solve issue #795

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -1327,7 +1327,12 @@
     }
 
     if (right) {
-        NSString *s = [NSString stringMadeOfSpaces:shiftWidth];
+        NSString *s;
+        if ([XVim instance].options.expandtab) {
+            s = [NSString stringMadeOfSpaces:shiftWidth];
+        } else {
+            s = @"\t";
+        }
         [self xvim_blockInsertFixupWithText:s mode:XVIM_INSERT_SPACES count:1 column:column lines:lines];
     } else {
         for (NSUInteger line = lines.begin; line <= lines.end; line++) {

--- a/XVim/XVimOptions.h
+++ b/XVim/XVimOptions.h
@@ -27,6 +27,7 @@
 @property BOOL alwaysuseinputsource; //XVim original
 @property BOOL blinkcursor;
 @property BOOL startofline;
+@property BOOL expandtab;
 
 - (id)getOption:(NSString*)name;
 - (void)setOption:(NSString*)name value:(id)value;

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -40,6 +40,7 @@
          @"alwaysuseinputsource", @"auis",
          @"blinkcursor", @"bc",
          @"startofline", @"sol",
+         @"expandtab", @"et",
          nil];
         
         // Default values
@@ -60,6 +61,7 @@
         _alwaysuseinputsource = NO;
         _blinkcursor = NO;
         _startofline = YES;
+        _expandtab = YES;
     }
     return self;
 }


### PR DESCRIPTION
- Add option `expandtab` with default YES.
- Use tab instead of spaces in `xvim_shift:right:withMotionPoint:count`
  for `right:YES` if `expandtab` is NO.
- Solves issue #795