### PR TITLE
Implement noexpandtab for `>>`, solve issue #795

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -218,6 +218,7 @@ Examples:
   [no]smartcase |
   [no]number |
   [no]hlsearch |
+  [no]expandtab | Only affects shift operations (e.g. `>>`, `v>`). When set to off, set tab width and insert mode behavior of tab key in XCode preferences (Text Editing -> Indentation). Defaults to on.
   guioptions | See below
   timeoutlen | The time in milliseconds that is waited for mapped key sequence to complete (default 1000)
   laststatus | 0 or 1 : status line is hidden, 2 : status line is displayed  (default 2)

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -1327,7 +1327,15 @@
     }
 
     if (right) {
-        NSString *s = [NSString stringMadeOfSpaces:shiftWidth];
+        NSString *s;
+        if ([XVim instance].options.expandtab) {
+            s = [NSString stringMadeOfSpaces:shiftWidth];
+        } else {
+            s = @"\t";
+            while ([s length] < (shiftWidth / ts.xvim_indentWidth)) {
+                s = [s stringByAppendingString:@"\t"];
+            }
+        }
         [self xvim_blockInsertFixupWithText:s mode:XVIM_INSERT_SPACES count:1 column:column lines:lines];
     } else {
         for (NSUInteger line = lines.begin; line <= lines.end; line++) {

--- a/XVim/Test/XVimTester+Operator.m
+++ b/XVim/Test/XVimTester+Operator.m
@@ -335,13 +335,34 @@
                                       @"    ddd\n"
                                       @"eee\n"
                                       @"fff";
-    
+
     static NSString* rshift_result2 = @"    aaa\n"
                                       @"    bbb\n"
                                       @"ccc\n"
                                       @"    ddd\n"
                                       @"    eee\n"
                                       @"fff";
+
+    static NSString* rshift_result0_1 = @"aaa\n"
+                                        @"\tbbb\n"
+                                        @"ccc\n"
+                                        @"ddd\n"
+                                        @"eee\n"
+                                        @"fff";
+
+    static NSString* rshift_result1_1 = @"aaa\n"
+                                        @"\tbbb\n"
+                                        @"\tccc\n"
+                                        @"\tddd\n"
+                                        @"eee\n"
+                                        @"fff";
+
+    static NSString* rshift_result2_1 = @"\taaa\n"
+                                        @"\tbbb\n"
+                                        @"ccc\n"
+                                        @"\tddd\n"
+                                        @"\teee\n"
+                                        @"fff";
     
     static NSString* lshift_result0 = @"        aaa\n"   // 0
                                       @"    bbb\n"       // 12 
@@ -568,6 +589,13 @@
             XVimMakeTestCase(text4, 1, 0, @"2>>jjj.", rshift_result2,24, 0),
             XVimMakeTestCase(text4, 5, 0, @">>jj`." , rshift_result0, 4, 0),
             XVimMakeTestCase(text4, 5, 0, @">>jj'." , rshift_result0, 8, 0),
+
+            // should create tabs with noexpandtab
+            XVimMakeTestCase(text4, 5, 0, @":set noexpandtab<CR>>>:set et<CR>"     , rshift_result0_1, 5, 0),
+            XVimMakeTestCase(text4, 5, 0, @":set noexpandtab<CR>3>>:set et<CR>"    , rshift_result1_1, 5, 0),
+            XVimMakeTestCase(text4, 1, 0, @":set noexpandtab<CR>2>>jjj.:set et<CR>", rshift_result2_1,15, 0),
+            XVimMakeTestCase(text4, 5, 0, @":set noexpandtab<CR>>>jj`.:set et<CR>" , rshift_result0_1, 4, 0),
+            XVimMakeTestCase(text4, 5, 0, @":set noexpandtab<CR>>>jj'.:set et<CR>" , rshift_result0_1, 5, 0),
             
             // < (Shift)
             // the following test case assumes that Xcode indent in the preference is 4 spaces

--- a/XVim/Test/XVimTester+Visual.m
+++ b/XVim/Test/XVimTester+Visual.m
@@ -54,6 +54,11 @@
                                       @"        ddd e-e fff\n"
                                       @"ggg hhh i_i\n" 
                                       @"    jjj kkk"; 
+
+    static NSString* rshift_result0_1 = @"\t\ta;a bbb ccc\n"
+                                        @"\t\tddd e-e fff\n"
+                                        @"ggg hhh i_i\n"
+                                        @"    jjj kkk";
     
     static NSString* rshift_result1 = @"    a;a bbb ccc\n"
                                       @"    ddd e-e fff\n"
@@ -133,6 +138,7 @@
             XVimMakeTestCase(text2, 0,  0, @"vj>."  , rshift_result0 , 8, 0), // #311
             XVimMakeTestCase(text2, 0,  0, @"vj>..u", rshift_result0 , 8, 0),
             XVimMakeTestCase(text2, 0,  0, @"vj>jj.", rshift_result1 ,36, 0),
+            XVimMakeTestCase(text2, 0,  0, @":set noexpandtab<CR>vj>.:set et<CR>", rshift_result0_1, 2, 0),
             
             XVimMakeTestCase(text2, 0,  0, @"<C-v>lljjd", C_v_d_result, 0, 0),
             XVimMakeTestCase(text1, 0,  0, @"vllcxxx<ESC>", vllccxxx_result, 2, 0),

--- a/XVim/XVimOptions.h
+++ b/XVim/XVimOptions.h
@@ -27,6 +27,7 @@
 @property BOOL alwaysuseinputsource; //XVim original
 @property BOOL blinkcursor;
 @property BOOL startofline;
+@property BOOL expandtab;
 
 - (id)getOption:(NSString*)name;
 - (void)setOption:(NSString*)name value:(id)value;

--- a/XVim/XVimOptions.m
+++ b/XVim/XVimOptions.m
@@ -40,6 +40,7 @@
          @"alwaysuseinputsource", @"auis",
          @"blinkcursor", @"bc",
          @"startofline", @"sol",
+         @"expandtab", @"et",
          nil];
         
         // Default values
@@ -60,6 +61,7 @@
         _alwaysuseinputsource = NO;
         _blinkcursor = NO;
         _startofline = YES;
+        _expandtab = YES;
     }
     return self;
 }


### PR DESCRIPTION
- Add option `expandtab` with default YES.
- Use tab instead of spaces in `xvim_shift:right:withMotionPoint:count`
  for `right:YES` if `expandtab` is NO.
- Solves issue #795