### PR TITLE
Add support for Xcode 7 GM

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Support Xcode Versions
   - Xcode5
   - Xcode6 GM
+  - Xcode7 GM
 
 ## INSTALL
   Download source code or clone the repo. Then,

--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -33,6 +33,7 @@
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
In order to support Xcode 7 GM released on September 9th, 2015, this
commit adds the correct UUID to the DVTPlugInCompatibilityUUIDs array in
the Info.plist. In addition, it highlights this compatibility in the
README.md