### PR TITLE
Add UUID for Xcode Beta 7.1

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -33,6 +33,7 @@
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
I don't know if UUID of Xcode 7 GM seed should be added as well, so only add 7.1 beta for my own needs.

UUID of  Xcode 7 GM seed is `<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>`