### PR TITLE
Fix #629

### DIFF
--- a/XVim.xcodeproj/project.pbxproj
+++ b/XVim.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		A2B0708719C5E9E30087CA0B /* XVimEval.m in Sources */ = {isa = PBXBuildFile; fileRef = A2B0708619C5E9E30087CA0B /* XVimEval.m */; };
 		A2F2621C182CEC3600AD3DC4 /* DVTSourceTextScrollView+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = A2F2621A182CEC3600AD3DC4 /* DVTSourceTextScrollView+XVim.m */; };
 		C9AE0E121B9EE51000FD240A /* IDEApplicationController+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = C9AE0E111B9EE51000FD240A /* IDEApplicationController+XVim.m */; };
+		D644B8D11BB778B800860B00 /* DVTTextCompletionController+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = D644B8CE1BB778B800860B00 /* DVTTextCompletionController+XVim.m */; settings = {ASSET_TAGS = (); }; };
+		D644B8D21BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = D644B8D01BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.m */; settings = {ASSET_TAGS = (); }; };
 		D65D3A2F1B92EB2800E67E3E /* NSColor+Extra.m in Sources */ = {isa = PBXBuildFile; fileRef = D65D3A2E1B92EB2800E67E3E /* NSColor+Extra.m */; };
 		E905EE3B18B0461E0052D3C1 /* DVTTextSidebarView+XVim.m in Sources */ = {isa = PBXBuildFile; fileRef = E905EE3818B045FE0052D3C1 /* DVTTextSidebarView+XVim.m */; };
 		ED37857D1A96F099003BE404 /* XVimReplacePromptEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = ED37857C1A96F099003BE404 /* XVimReplacePromptEvaluator.m */; };
@@ -299,6 +301,10 @@
 		C3FA1A1C1532648700059BF6 /* XVimWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XVimWindow.m; path = XVim/XVimWindow.m; sourceTree = SOURCE_ROOT; };
 		C9AE0E101B9EE51000FD240A /* IDEApplicationController+XVim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "IDEApplicationController+XVim.h"; path = "XVim/IDEApplicationController+XVim.h"; sourceTree = SOURCE_ROOT; };
 		C9AE0E111B9EE51000FD240A /* IDEApplicationController+XVim.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "IDEApplicationController+XVim.m"; path = "XVim/IDEApplicationController+XVim.m"; sourceTree = SOURCE_ROOT; };
+		D644B8CD1BB778B800860B00 /* DVTTextCompletionController+XVim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "DVTTextCompletionController+XVim.h"; path = "XVim/DVTTextCompletionController+XVim.h"; sourceTree = SOURCE_ROOT; };
+		D644B8CE1BB778B800860B00 /* DVTTextCompletionController+XVim.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "DVTTextCompletionController+XVim.m"; path = "XVim/DVTTextCompletionController+XVim.m"; sourceTree = SOURCE_ROOT; };
+		D644B8CF1BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "DVTTextCompletionListWindowController+XVim.h"; path = "XVim/DVTTextCompletionListWindowController+XVim.h"; sourceTree = SOURCE_ROOT; };
+		D644B8D01BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "DVTTextCompletionListWindowController+XVim.m"; path = "XVim/DVTTextCompletionListWindowController+XVim.m"; sourceTree = SOURCE_ROOT; };
 		D65D3A2D1B92EB2800E67E3E /* NSColor+Extra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSColor+Extra.h"; path = "XVim/NSColor+Extra.h"; sourceTree = "<group>"; };
 		D65D3A2E1B92EB2800E67E3E /* NSColor+Extra.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSColor+Extra.m"; path = "XVim/NSColor+Extra.m"; sourceTree = "<group>"; };
 		E905EE3718B045FE0052D3C1 /* DVTTextSidebarView+XVim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "DVTTextSidebarView+XVim.h"; path = "XVim/DVTTextSidebarView+XVim.h"; sourceTree = SOURCE_ROOT; };
@@ -689,6 +695,10 @@
 		C345DDB8154CCF79009F232E /* Event Dispatchers */ = {
 			isa = PBXGroup;
 			children = (
+				D644B8CD1BB778B800860B00 /* DVTTextCompletionController+XVim.h */,
+				D644B8CE1BB778B800860B00 /* DVTTextCompletionController+XVim.m */,
+				D644B8CF1BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.h */,
+				D644B8D01BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.m */,
 				E905EE3718B045FE0052D3C1 /* DVTTextSidebarView+XVim.h */,
 				E905EE3818B045FE0052D3C1 /* DVTTextSidebarView+XVim.m */,
 				C38A5B3F15272B0500E1448D /* DVTSourceTextView+XVim.h */,
@@ -806,6 +816,7 @@
 				A28F423E17EEDBC200A3F7AE /* XVimNumericEvaluator.m in Sources */,
 				A28F423F17EEDBC200A3F7AE /* XVimKeymap.m in Sources */,
 				A259E2231B3C263B006000D9 /* NSURL+XVimXcodeModule.m in Sources */,
+				D644B8D21BB778B800860B00 /* DVTTextCompletionListWindowController+XVim.m in Sources */,
 				A28F424017EEDBC200A3F7AE /* XVimExCommand.m in Sources */,
 				A28F424117EEDBC200A3F7AE /* XVimSearch.m in Sources */,
 				A28F424217EEDBC200A3F7AE /* XVimOptions.m in Sources */,
@@ -816,6 +827,7 @@
 				A28F424617EEDBC200A3F7AE /* XVimWindowEvaluator.m in Sources */,
 				A28F424717EEDBC200A3F7AE /* XVimTextObjectEvaluator.m in Sources */,
 				A28F424817EEDBC200A3F7AE /* XVimWindow.m in Sources */,
+				D644B8D11BB778B800860B00 /* DVTTextCompletionController+XVim.m in Sources */,
 				A28F424917EEDBC200A3F7AE /* NSString+VimHelper.m in Sources */,
 				A2752F5419F3E00200D1642C /* XVimQuickFixView.m in Sources */,
 				A28F424A17EEDBC200A3F7AE /* XVimGActionEvaluator.m in Sources */,

--- a/XVim/DVTTextCompletionController+XVim.h
+++ b/XVim/DVTTextCompletionController+XVim.h
@@ -1,0 +1,16 @@
+//
+//  DVTTextCompletionController+XVim.h
+//  XVim
+//
+//  Created by Muronaka Hiroaki on 2015/09/27.
+//
+//
+
+#import "DVTKit.h"
+
+@interface DVTTextCompletionController (XVim)
+
++(void)xvim_initialize;
++(void)xvim_finalize;
+
+@end

--- a/XVim/DVTTextCompletionController+XVim.m
+++ b/XVim/DVTTextCompletionController+XVim.m
@@ -1,0 +1,32 @@
+//
+//  DVTTextCompletionController+XVim.m
+//  XVim
+//
+//  Created by Muronaka Hiroaki on 2015/09/27.
+//
+//
+
+#import "DVTTextCompletionController+XVim.h"
+#import "DVTTextCompletionListWindowController+XVim.h"
+#import "NSObject+XVimAdditions.h"
+
+@implementation DVTTextCompletionController (XVim)
+
++ (void)xvim_initialize {
+    [self xvim_swizzleInstanceMethod:@selector(acceptCurrentCompletion) with:@selector(xvim_acceptCurrentCompletion)];
+}
+
++ (void)xvim_finalize {
+    [self xvim_swizzleInstanceMethod:@selector(acceptCurrentCompletion) with:@selector(xvim_acceptCurrentCompletion)];
+}
+
+- (BOOL)xvim_acceptCurrentCompletion {
+    
+    if([self.currentSession.listWindowController tryExpandingCompletion]) {
+        return YES;
+    }
+    
+    return [self xvim_acceptCurrentCompletion];
+}
+
+@end

--- a/XVim/DVTTextCompletionListWindowController+XVim.h
+++ b/XVim/DVTTextCompletionListWindowController+XVim.h
@@ -1,0 +1,15 @@
+//
+//  DVTTextCompletionListWindowController+XVim.h
+//  XVim
+//
+//  Created by Muronaka Hiroaki on 2015/09/27.
+//
+//
+
+#import "DVTKit.h"
+
+@interface DVTTextCompletionListWindowController (XVim)
+
+- (BOOL)tryExpandingCompletion;
+
+@end

--- a/XVim/DVTTextCompletionListWindowController+XVim.m
+++ b/XVim/DVTTextCompletionListWindowController+XVim.m
@@ -1,0 +1,86 @@
+//
+//  DVTTextCompletionListWindowController+XVim.m
+//  XVim
+//
+//  Created by Muronaka Hiroaki on 2015/09/27.
+//
+//
+
+#import "IDEKit.h"
+#import "DVTTextCompletionListWindowController+XVim.h"
+#import "XVim.h"
+
+@implementation DVTTextCompletionListWindowController (XVim)
+
+- (BOOL)tryExpandingCompletion
+{
+    IDEIndexCompletionItem *item = [self _selectedCompletionItem];
+    
+    [self expandCompletionItem:item];
+    
+    return NO;
+}
+
+
+
+-(void)expandCompletionItem:(IDEIndexCompletionItem*)completionItem {
+    NSMutableString* tempRepeatRegister = [XVim instance].tempRepeatRegister;
+    unichar lastChar = [tempRepeatRegister characterAtIndex:tempRepeatRegister.length - 1];
+    if( [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:lastChar] ) {
+        [tempRepeatRegister deleteCharactersInRange:NSMakeRange(tempRepeatRegister.length - 1, 1)];
+    }
+    
+// This is a little better if completionText contains "< # code # >".
+//    NSRange range = [self rangeOfExpandFromItemName:completionItem.name tempRegister:tempRepeatRegister];
+//    if( range.location != NSNotFound ) {
+//        [tempRepeatRegister replaceCharactersInRange:range withString:completionItem.completionText];
+//        return;
+//    }
+//    
+    
+    DVTSourceTextView *textView = (DVTSourceTextView *)self.session.textView;
+    if(self.session.wordStartLocation == NSNotFound) {
+        return;
+    }
+    
+    
+    NSRange wordRange = NSMakeRange(self.session.wordStartLocation, self.session.cursorLocation - self.session.wordStartLocation);
+    NSString* word = [textView.string substringWithRange:wordRange];
+    NSRange range = [self rangeOfExpandWord:word tempRegister:tempRepeatRegister];
+    
+    if( range.location != NSNotFound ) {
+        [tempRepeatRegister replaceCharactersInRange:range withString:completionItem.completionText];
+    }
+}
+
+-(NSRange)rangeOfExpandFromItemName:(NSString*)itemName tempRegister:(NSString*)tempRepeatRegister {
+    NSString* lowercaseTempRepeatRegister = [tempRepeatRegister lowercaseString];
+    NSString* lowercaseItemName = [itemName lowercaseString];
+    
+    NSRange result = NSMakeRange(NSNotFound, 0);
+    for(NSUInteger i = lowercaseItemName.length; i > 0; i--) {
+        NSString* itemSubString = [[lowercaseItemName substringToIndex:i] lowercaseString];
+        if( [lowercaseTempRepeatRegister hasSuffix:itemSubString] ) {
+            result = NSMakeRange(tempRepeatRegister.length - i, itemSubString.length);
+            break;
+        }
+    }
+    return result;
+}
+
+-(NSRange)rangeOfExpandWord:(NSString*)word tempRegister:(NSString*)tempRepeatRegister {
+    NSString* lowercaseTempRepeatRegister = [tempRepeatRegister lowercaseString];
+    NSString* lowercaseWord = [word lowercaseString];
+    
+    NSRange prevRange = NSMakeRange(NSNotFound, 0);
+    for(NSInteger i = (NSInteger)lowercaseTempRepeatRegister.length - 1; i >= 0; i--) {
+        NSRange currentRange = NSMakeRange((NSUInteger)i, lowercaseTempRepeatRegister.length - (NSUInteger)i);
+        if( ![lowercaseWord hasSuffix:[lowercaseTempRepeatRegister substringWithRange:currentRange]] ) {
+            break;
+        }
+        prevRange = currentRange;
+    }
+    return prevRange;
+}
+
+@end

--- a/XVim/XVim.h
+++ b/XVim/XVim.h
@@ -26,7 +26,6 @@
 @class XVimRegisterManager;
 @class XVimTester;
 
-
 extern NSString * const XVimDocumentChangedNotification;
 extern NSString * const XVimDocumentPathKey;
 
@@ -54,6 +53,7 @@ extern NSString * const XVimDocumentPathKey;
 @property (copy) NSString* document;
 @property (nonatomic) BOOL isExecuting; // For @x command executing
 @property (nonatomic) BOOL foundRangesHidden;
+@property (strong,nonatomic) XVimMutableString* tempRepeatRegister;
 
 // XVimKeymapProvider protocol
 - (XVimKeymap*)keymapForMode:(XVIM_MODE)mode;

--- a/XVim/XVim.h
+++ b/XVim/XVim.h
@@ -53,7 +53,7 @@ extern NSString * const XVimDocumentPathKey;
 @property (copy) NSString* document;
 @property (nonatomic) BOOL isExecuting; // For @x command executing
 @property (nonatomic) BOOL foundRangesHidden;
-@property (strong,nonatomic) XVimMutableString* tempRepeatRegister;
+@property (strong, nonatomic) XVimMutableString* tempRepeatRegister;
 
 // XVimKeymapProvider protocol
 - (XVimKeymap*)keymapForMode:(XVIM_MODE)mode;

--- a/XVim/XVim.m
+++ b/XVim/XVim.m
@@ -52,7 +52,6 @@ NSString * const XVimDocumentPathKey = @"XVimDocumentPathKey";
 }
 @property (strong,nonatomic) XVimRegisterManager* registerManager;
 @property (strong,nonatomic) XVimMutableString* lastOperationCommands;
-@property (strong,nonatomic) XVimMutableString* tempRepeatRegister;
 - (void)parseRcFile;
 @end
 

--- a/XVim/XVimHookManager.m
+++ b/XVim/XVimHookManager.m
@@ -18,6 +18,7 @@
 #import "NSObject+XVimAdditions.h"
 #import "DVTSourceTextView+XVim.h"
 #import "IDEApplicationController+XVim.h"
+#import "DVTTextCompletionController+XVim.h"
 
 @implementation IDEWorkspaceWindow (XVim)
 
@@ -54,6 +55,7 @@
     [IDESourceCodeEditor xvim_initialize];
     [IDEEditor xvim_initialize];
     [IDEApplicationController xvim_initialize];
+    [DVTTextCompletionController xvim_initialize];
 }
 
 @end

--- a/XVim/XVimRegister.h
+++ b/XVim/XVimRegister.h
@@ -27,6 +27,7 @@ typedef enum{
 // XVimRegisterManager must handle all the requests.
 @interface XVimRegisterManager : NSObject
 @property (strong) NSString* lastExecutedRegister;
+@property(readonly) XVimRegister* recordingRegister;
 /**
  * Returns XVimRegister object for the registry "name".
  * The register may be invalid after a few key input because


### PR DESCRIPTION
I fixed it.

But it doesn't work correctly if completionText contains placeholder.

For example
```obj-c
// You type the code using completion.
[NSString stringWithFormat:@"Test"]

// Xcode will complete like this if completionText contains placeholder.
[NSString  stringWithFormat:(nonnull NSString *), ... @"Test"];
```