### PR TITLE
XVimProject/XVim#854 develop failing to build on Xcode 6.1

### DIFF
--- a/XVim/IDESourceCodeEditor+XVim.m
+++ b/XVim/IDESourceCodeEditor+XVim.m
@@ -31,16 +31,14 @@
     id obj = [self xvim_initWithNibName:name bundle:bundle document:doc];
     id v = [obj view];
     NSView* container;
-    DEBUG_LOG(@"v [%@]", v);
     if ([NSStringFromClass([v class]) isEqualToString:@"DVTControllerContentView"]) {
-        // Xcode7 or Xcode6.4???
+        // Xcode7 or Xcode6.4
         container = [v contentView];
     } else {
-        // Xcode6.1 ???
+        // Xcode6.1
         // container is IDESourceCodeEditorContainerView
         container = [obj containerView];
     }
-    DEBUG_LOG("container [%@]", container);
 
     // Insert status line
     if( nil != container ){

--- a/XVim/IDESourceCodeEditor+XVim.m
+++ b/XVim/IDESourceCodeEditor+XVim.m
@@ -29,8 +29,19 @@
 
 - (id)xvim_initWithNibName:(NSString*)name bundle:(NSBundle*)bundle document:(IDEEditorDocument*)doc{
     id obj = [self xvim_initWithNibName:name bundle:bundle document:doc];
-    NSView* container = [[obj view] contentView];
-    
+    id v = [obj view];
+    NSView* container;
+    DEBUG_LOG(@"v [%@]", v);
+    if ([NSStringFromClass([v class]) isEqualToString:@"DVTControllerContentView"]) {
+        // Xcode7 or Xcode6.4???
+        container = [v contentView];
+    } else {
+        // Xcode6.1 ???
+        // container is IDESourceCodeEditorContainerView
+        container = [obj containerView];
+    }
+    DEBUG_LOG("container [%@]", container);
+
     // Insert status line
     if( nil != container ){
         // TODO: Observe DVTFontAndColorSourceTextSettingsChangedNotification to change color of status bar


### PR DESCRIPTION
Turns out commit 125c207a73d9f7584d52c2b6bd217f17ef327e20 used a feature only available in newer versions of Xcode. This new logic, supplied by pebble8888, works in both 6.1 and 6.4.