### PR TITLE
XVimProject/XVim#845 Allow whitespace agnostic unit testing

### DIFF
--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -20,6 +20,7 @@
  **/
 
 #import "XVimTester.h"
+#import "DVTFoundation.h"
 
 @implementation XVimTester (Issues)
 - (NSArray*)issues_testcases{
@@ -42,7 +43,8 @@
                                  @"\n"
                                  @"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     
-    static NSString* issue_606_result = @"        aaa bbb ccc\n";
+    static NSString* issue_606_result_spaces = @"        aaa bbb ccc\n";
+    static NSString* issue_606_result_tabs = @"		aaa bbb ccc\n";
 
 
     static NSString* issue_776_text = @"";
@@ -72,8 +74,11 @@
             XVimMakeTestCase(@"abc\n", 2, 0, @"cl<C-w><ESC>p", @"c\n", 0, 0),
             
             XVimMakeTestCase(issue_587, 5, 0, @"j", issue_587, 6, 0 ),  // Issue #587 xvim_sb_init related
-            
-            XVimMakeTestCase(text0, 0, 0, @"i<TAB><ESC>.", issue_606_result , 7, 0 ),  // Issue #606. Repeating tab insertion crashes Xcode. (This test assumes that tab expands 4 space)
+
+            ( [[DVTTextPreferences preferences] useTabsToIndent] ) // check for tab/space indentation
+                ? XVimMakeTestCase( text0, 0, 0, @"i<TAB><ESC>.", issue_606_result_tabs, 1, 0 )    // Issue #606. Repeating tab insertion crashes Xcode.
+                : XVimMakeTestCase( text0, 0, 0, @"i<TAB><ESC>.", issue_606_result_spaces, 7, 0 ), // Issue #606. Repeating tab insertion crashes Xcode.
+
             XVimMakeTestCase(issue_776_text, 0, 0, @"O<ESC>", issue_776_result,  0, 0), // Issue #776 crash
             XVimMakeTestCase(issue_805_text, 33, 0, @"dd", issue_805_result, 0, 0), // Issue #805
             XVimMakeTestCase(issue_809_a_text, 5, 0, @"dw", issue_809_a_result, 4, 0),

--- a/XVim/Test/XVimTester+Operator.m
+++ b/XVim/Test/XVimTester+Operator.m
@@ -7,6 +7,7 @@
 //
 
 #import "XVimTester.h"
+#import "DVTFoundation.h"
 
 @implementation XVimTester (Operator)
 - (NSArray*)operator_testcases{
@@ -249,9 +250,12 @@
     static NSString* oO_text = @"int abc(){\n"  // 0 4
                                @"}\n";          // 11
     
-    static NSString* oO_result = @"int abc(){\n" // This result may differ from editor setting. This is for 4 spaces for indent.
-                                 @"    \n"      // 11
-                                 @"}\n";
+    static NSString* oO_result_spaces = @"int abc(){\n" // This result may differ from editor setting. This is for 4 spaces for indent.
+                                        @"    \n"       // 11
+                                        @"}\n";
+    static NSString* oO_result_tabs = @"int abc(){\n"
+                                      @"	\n"
+                                      @"}\n";
     
     static NSString* oO_result2 = @"int abc(){\n" 
                                   @"}\n"
@@ -621,8 +625,14 @@
             XVimMakeTestCase(text0, 0,  0,    @"g~w", g_tilde_w_result,   0, 0),
             
             // o, O
-            XVimMakeTestCase(oO_text,  4, 0, @"o<ESC>", oO_result, 14, 0),
-            XVimMakeTestCase(oO_text, 11, 0, @"O<ESC>", oO_result, 14, 0),
+            ( [[DVTTextPreferences preferences] useTabsToIndent] ) // check for tab/space indentation
+                ? XVimMakeTestCase(oO_text,  4, 0, @"o<ESC>", oO_result_tabs, 11, 0)
+                : XVimMakeTestCase(oO_text,  4, 0, @"o<ESC>", oO_result_spaces, 14, 0),
+
+            ( [[DVTTextPreferences preferences] useTabsToIndent] ) // check for tab/space indentation
+                ? XVimMakeTestCase(oO_text, 11, 0, @"O<ESC>", oO_result_tabs, 11, 0)
+                : XVimMakeTestCase(oO_text, 11, 0, @"O<ESC>", oO_result_spaces, 14, 0),
+
             XVimMakeTestCase(oO_text, 13, 0, @"O<ESC>", oO_result2, 13, 0), // Issue #675
             
             // Insert and Ctrl-o


### PR DESCRIPTION
Currently, if Xcode is set to indent with tabs a few unit tests (that are dependent upon whitespace settings) fail. We now read in the Xcode preferences and base our tests off of that setting.

Note: Although it is easy enough to detect tabs/spaces indentation and although it is easy enough to detect how many spaces are inserted for space indentation, it is not as straightforward to test spaces. The biggest problem is the tabWidth for inserting spaces. This can vary dramatically and since most of our test case strings are hard coded, this is not such an easy task. This makes tab indentation testing look more appealing, actually, in my humble opinion. If we wanted to support various tabWidth's for space indentation, we would need to start generating some of the unit test strings programmatically; something I'm just not quite willing to invest time in yet. Have other higher priorities ;)