### PR TITLE
Adding additional z mappings for folding.

### DIFF
--- a/Documents/Users/FeatureList.md
+++ b/Documents/Users/FeatureList.md
@@ -66,6 +66,22 @@ Visual mode: u, U, ~, gu, gU
 
 u, C-r
 
+## Folds
+
+zc, zC, zm, zM, zo, zO, zr, zR
+
+zc - fold
+(Note: zC is mapped to zc as Xcode does not have similar vim behavior.)
+
+zM - fold all
+(Note: zm is mapped to zM as Xcode does not have similar vim behavior.)
+
+zo - unfold
+(Note: zO is mapped to zo as Xcode does not have similar vim behavior.)
+
+zR - unfold all
+(Note: zr is mapped to zR as Xcode does not have similar vim behavior.)
+
 ## Visual
 v, V, Ctrl-v
 

--- a/XVim/XVimZEvaluator.m
+++ b/XVim/XVimZEvaluator.m
@@ -17,6 +17,47 @@
     return nil;
 }
 
+- (XVimEvaluator*)c{
+    [NSApp sendAction:@selector(fold:) to:nil from:self];
+    return nil;
+}
+
+- (XVimEvaluator*)C{
+    // Xcode doesn't have a zC type feature so default to zc
+    return [self c];
+}
+
+- (XVimEvaluator*)m{
+    // Xcode doesn't have a zm type feature so default to zM
+    return [self M];
+}
+
+- (XVimEvaluator*)M{
+    [NSApp sendAction:@selector(foldAllComments:) to:nil from:self];
+    [NSApp sendAction:@selector(foldAllMethods:) to:nil from:self];
+    return nil;
+}
+
+- (XVimEvaluator*)o{
+    [NSApp sendAction:@selector(unfold:) to:nil from:self];
+    return nil;
+}
+
+- (XVimEvaluator*)O{
+    // Xcode doesn't have a zO type feature so default to zo
+    return [self o];
+}
+
+- (XVimEvaluator*)r{
+    // Xcode doesn't have a zr type feature so default to zR
+    return [self R];
+}
+
+- (XVimEvaluator*)R{
+    [NSApp sendAction:@selector(unfoldAll:) to:nil from:self];
+    return nil;
+}
+
 - (XVimEvaluator*)t{
     [self.sourceView xvim_scrollTop:([self numericMode]?[self numericArg]:0) firstNonblank:NO];
     return nil;


### PR DESCRIPTION
Tried to hook into Xcode's menus whereever possible. Not all of vim's functionality is available in Xcode, so I made due with what I had.

In some cases, I went with what seems to make the most sense rather than strictly adhering to what the user wanted. For example, C-o opens a fold. C-O should open a fold under the cursor recursively. However, Xcode doesn't support this. So, rather than disable the C-O mapping entirely, I defaulted it to C-o instead.