### PR TITLE
Support swift format module header for bang in Xcode7

### DIFF
--- a/XVim/NSURL+XVimXcodeModule.h
+++ b/XVim/NSURL+XVimXcodeModule.h
@@ -14,4 +14,13 @@
 - (NSString*)xcode_source_header;
 - (NSString*)xcode_swift_sdk;
 - (NSString*)xcode_swift_target;
+- (NSString*)xcode_clang_defines;
+- (NSString*)xcode_clang_header_paths;
+- (NSString*)xcode_clang_user_header_paths;
+- (NSString*)xcode_source_file;
+- (NSString*)xcode_swift_framework_paths;
+- (NSString*)xcode_swift_header_paths;
+- (NSString*)xcode_swift_module_name;
+- (NSString*)xvim_header_file;
+- (NSString*)xvim_swiftCacheFilePath;
 @end

--- a/XVim/NSURL+XVimXcodeModule.m
+++ b/XVim/NSURL+XVimXcodeModule.m
@@ -6,6 +6,7 @@
 //
 
 #import "NSURL+XVimXcodeModule.h"
+#import "Logger.h"
 
 @implementation NSURL (XVimXcodeModule)
 - (BOOL)isXcodeModuleSchemeURL;
@@ -13,26 +14,22 @@
     return [self.scheme isEqualToString:@"x-xcode-module"];
 }
 
-- (NSString*)xcode_language
-{
-    return self.queryString[@"language"];
-}
+#pragma mark - Xcode6
+- (NSString*)xcode_language      { return self.queryString[@"language"]; }
+- (NSString*)xcode_source_header { return self.queryString[@"source-header"]; }
+- (NSString*)xcode_swift_sdk     { return self.queryString[@"swift-sdk"]; }
+- (NSString*)xcode_swift_target  { return self.queryString[@"swift-target"]; }
 
-- (NSString*)xcode_source_header
-{
-    return self.queryString[@"source-header"];
-}
+#pragma mark - add at Xcode7
+- (NSString*)xcode_clang_defines            { return self.queryString[@"clang-defines"]; }
+- (NSString*)xcode_clang_header_paths       { return self.queryString[@"clang-header-paths" ]; }
+- (NSString*)xcode_clang_user_header_paths  { return self.queryString[@"clang-user-header-paths" ]; }
+- (NSString*)xcode_source_file              { return self.queryString[@"source-file" ]; }
+- (NSString*)xcode_swift_framework_paths    { return self.queryString[@"swift-framework-paths" ]; }
+- (NSString*)xcode_swift_header_paths       { return self.queryString[@"swift-header-paths" ]; }
+- (NSString*)xcode_swift_module_name        { return self.queryString[@"swift-module-name" ]; }
 
-- (NSString*)xcode_swift_sdk
-{
-    return self.queryString[@"swift-sdk"];
-}
-
-- (NSString*)xcode_swift_target
-{
-    return self.queryString[@"swift-target"];
-}
-
+#pragma mark -
 - (NSDictionary*)queryString
 {
     NSMutableDictionary *queryStringDictionary = [NSMutableDictionary dictionary];
@@ -44,6 +41,34 @@
         [queryStringDictionary setObject:value forKey:key];
     }
     return queryStringDictionary;
+}
+
+- (NSString*)xvim_header_file
+{
+    // Xcode7
+    NSString* str = self.xcode_source_file;
+    if (str == nil) {
+        // Xcode6
+        str = self.xcode_source_header;
+    }
+    return str;
+}
+
+- (NSString*)xvim_swiftCacheFilePath
+{
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSString* xvim_folder = [NSHomeDirectory() stringByAppendingPathComponent:@".xvim"];
+    NSString* xvim_caches_folder = [xvim_folder stringByAppendingPathComponent:@"caches"];
+    if (![fm fileExistsAtPath:xvim_caches_folder]){
+        [fm createDirectoryAtPath:xvim_caches_folder withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    NSString* header_path = [self xvim_header_file];
+    if (header_path == nil) {
+        return nil;
+    }
+    NSString* name = header_path.lastPathComponent.stringByDeletingPathExtension;
+    NSString* swiftpath = [xvim_caches_folder stringByAppendingPathComponent:[name stringByAppendingPathExtension:@"swift"]];
+    return swiftpath; 
 }
 
 @end

--- a/XVim/XVimExCommand.m
+++ b/XVim/XVimExCommand.m
@@ -1555,7 +1555,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
         // We use converted text as is.
         // The converted swift file name is set to current file name symbol '%'.
         NSFileManager* fm = [NSFileManager defaultManager];
-        NSString* swiftpath = [NSHomeDirectory() stringByAppendingPathComponent:@".xvimtmp.swift"];
+        NSString* swiftpath = [documentURL xvim_swiftCacheFilePath];
         NSString* str = window.sourceView.string;
         if( str.length > 0 ){
             NSData* data = [NSData dataWithBytes:(void*)str.UTF8String length:str.length];
@@ -1563,7 +1563,7 @@ static const NSTimeInterval EXTERNAL_COMMAND_TIMEOUT_SECS = 5.0;
             contextForExCmd[@"%"] = swiftpath ? swiftpath: @"";
         }
         // The Objective-C Framework header file is set to alternate file name symbol '#'.
-        NSString* objc_header = documentURL.xcode_source_header;
+        NSString* objc_header = documentURL.xvim_header_file;
         if( objc_header.length > 0 ){
             contextForExCmd[@"#"] = objc_header ? objc_header: @"";
         }


### PR DESCRIPTION
Since 'x-xcode-module' scheme is modified in Xcode7, add support that.
Also swift file path is changed to ~/.xvim/caches/. 