### PR TITLE
#import typo in XVim/IDESourceCodeEditor+XVim.m

### DIFF
--- a/XVim/IDESourceCodeEditor+XVim.m
+++ b/XVim/IDESourceCodeEditor+XVim.m
@@ -14,7 +14,7 @@
 #import "XVimStatusLine.h"
 #import "XVim.h"
 #import "NSObject+XVimAdditions.h"
-#import "NSobject+ExtraData.h"
+#import "NSObject+ExtraData.h"
 #import <objc/runtime.h>
 
 @implementation IDESourceCodeEditor(XVim)


### PR DESCRIPTION
On case sensitive system XVim/IDESourceCodeEditor+XVim.m failed to compile with "fatal error: 'NSobject+ExtraData.h' file not found". Note the letter "o" in #import is lowercase, while the "O" in filename is uppercase.