### PR TITLE
Override command line background colour

### DIFF
--- a/XVim/XVimCommandLine.m
+++ b/XVim/XVimCommandLine.m
@@ -46,6 +46,7 @@
     
         [_command setFont:textFont];
         [_command setTextColor:textColor];
+        [_command setBackgroundColor:textBackgroundColor];
         [_command invalidateIntrinsicContentSize];
     
         [_argument setFont:textFont];
@@ -195,7 +196,6 @@
         _command = [[XVimCommandField alloc] init];
         [_command setEditable:NO];
         [_command setSelectable:NO];
-        [_command setBackgroundColor:[NSColor clearColor]];
         [_command setHidden:YES];
         [_command setTranslatesAutoresizingMaskIntoConstraints:NO];
         // Width


### PR DESCRIPTION
This is a fix for #893.

While it works cleanly, there's probably a better way of dealing with this. I'm open to discussion either in this Pull Request or in the [original issue](https://github.com/XVimProject/XVim/issues/893). As it stands however, this does fix the issue!