### PR TITLE
Add DVTPlugInCompatibilityUUID of Xcode 7.2

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -36,6 +36,7 @@
 		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
 		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
Xvim plugin doesn't work after updating Xcode 7.2