### PR TITLE
Fix import typo in IDEPlaygroundEditor+XVim.m

### DIFF
--- a/XVim/IDEPlaygroundEditor+XVim.m
+++ b/XVim/IDEPlaygroundEditor+XVim.m
@@ -13,7 +13,7 @@
 #import "XVimStatusLine.h"
 #import "XVim.h"
 #import "NSObject+XVimAdditions.h"
-#import "NSobject+ExtraData.h"
+#import "NSObject+ExtraData.h"
 #import <objc/runtime.h>
 #import "IDEPlaygroundEditor+XVim.h"
 


### PR DESCRIPTION
Project fails to build due to typo on
case-sensitive filesystems