### PR TITLE
Add implementation of gE / ge

### DIFF
--- a/XVim/NSTextStorage+VimOperation.m
+++ b/XVim/NSTextStorage+VimOperation.m
@@ -889,16 +889,55 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t *sb, NSUInteger tab
  * Returns position of the end of count words backward.
  **/
 - (NSUInteger)endOfWordsBackward:(NSUInteger)index count:(NSUInteger)count option:(MOTION_OPTION)opt{
-    // ge is equivalent to b-e
-    NSUInteger beginning = [self wordsBackward:index count:count+1 option:opt];
-    NSUInteger end = [self endOfWordsForward:beginning count:1 option:opt];
-
-    // If index == end, Vim would move the cursor to the beginning of the line.
-    if (index == end) {
-        return beginning;
+    ASSERT_VALID_RANGE_WITH_EOF(index);
+    NSAssert( 0 != count , @"count must be greater than 0");
+    if( [self isEOF:index] || [self isLastCharacter:index]){
+        return index;
     }
-
-    return end;
+    NSUInteger pos = index;
+    NSUInteger word_count = 0;
+    NSString *string = [self xvim_string];
+    for( ; ; --pos ){
+        if( pos == 0 ){
+            break;
+        }
+        NSRange rph = [self rangePlaceHolder:pos option:opt];
+        if( rph.location != NSNotFound ){
+            // placeholder
+            if( (opt&MOTION_OPTION_CHANGE_WORD) || pos != index ){
+                word_count++;
+            }
+            pos = NSMaxRange(rph) - 1;
+            if( [self isLastCharacter:pos] ){
+                break;
+            }
+        } else if( [self isNewline:pos] && [self isNewline:pos+1] ){
+            // two NewLine
+            if( opt&MOTION_OPTION_CHANGE_WORD ){
+                word_count++;
+            }
+        } else if( (opt&MOTION_OPTION_CHANGE_WORD) && isWhitespace([string characterAtIndex:index]) ){
+            // begins with space in case of 'cw'
+            if( [self isWhitespace:pos] && ![self isWhitespace:pos+1] ){
+                word_count++;
+            }
+        } else if( ![self isWhitespaceOrNewline:pos] ){
+            if( (![self isWhitespaceOrNewline:pos+1] &&
+                 !(opt & BIGWORD) &&
+                 [self isKeyword:pos] != [self isKeyword:pos+1] ) ||
+                [self isWhitespaceOrNewline:pos+1] ||
+               [self rangePlaceHolder:pos+1 option:opt].location != NSNotFound
+               ){
+                if( (opt&MOTION_OPTION_CHANGE_WORD) || pos != index ){
+                    word_count++;
+                }
+            }
+        }
+        if( word_count == count ){
+            break;
+        }
+    }
+    return pos;
 }
 
 

--- a/XVim/NSTextStorage+VimOperation.m
+++ b/XVim/NSTextStorage+VimOperation.m
@@ -889,7 +889,23 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t *sb, NSUInteger tab
  * Returns position of the end of count words backward.
  **/
 - (NSUInteger)endOfWordsBackward:(NSUInteger)index count:(NSUInteger)count option:(MOTION_OPTION)opt{
-    // TODO: Implement!
+    NSUInteger pos = index;
+    NSUInteger word_count = 0;
+    NSString *string = [self xvim_string];
+    BOOL whitespaceFound = NO;
+    for( ; ; --pos ){
+        // Look for whitespace
+        if (isWhitespace([string characterAtIndex:pos])) {
+            whitespaceFound = YES;
+            word_count++;
+        } else {
+            // Return the first non-whitespace character after a whitespace
+            // or return position 0
+            if ((whitespaceFound && word_count == count) || pos == 0) {
+                return pos;
+            }
+        }
+    }
     return index;
 }
 

--- a/XVim/NSTextStorage+VimOperation.m
+++ b/XVim/NSTextStorage+VimOperation.m
@@ -889,24 +889,16 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t *sb, NSUInteger tab
  * Returns position of the end of count words backward.
  **/
 - (NSUInteger)endOfWordsBackward:(NSUInteger)index count:(NSUInteger)count option:(MOTION_OPTION)opt{
-    NSUInteger pos = index;
-    NSUInteger word_count = 0;
-    NSString *string = [self xvim_string];
-    BOOL whitespaceFound = NO;
-    for( ; ; --pos ){
-        // Look for whitespace
-        if (isWhitespace([string characterAtIndex:pos])) {
-            whitespaceFound = YES;
-            word_count++;
-        } else {
-            // Return the first non-whitespace character after a whitespace
-            // or return position 0
-            if ((whitespaceFound && word_count == count) || pos == 0) {
-                return pos;
-            }
-        }
+    // ge is equivalent to b-e
+    NSUInteger beginning = [self wordsBackward:index count:count+1 option:opt];
+    NSUInteger end = [self endOfWordsForward:beginning count:1 option:opt];
+
+    // If index == end, Vim would move the cursor to the beginning of the line.
+    if (index == end) {
+        return beginning;
     }
-    return index;
+
+    return end;
 }
 
 

--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -663,6 +663,10 @@
                 self.selectionToEOL = YES;
                 [self xvim_moveCursor:r.end preserveColumn:NO];
                 break;
+            case MOTION_END_OF_WORD_BACKWARD:
+                self.selectionToEOL = NO;
+                [self xvim_moveCursor:r.begin preserveColumn:NO];
+                break;
 
             default:
                 self.selectionToEOL = NO;
@@ -2367,7 +2371,9 @@
             end = [self.textStorage endOfWordsForward:begin count:motion.count option:motion.option];
             break;
         case MOTION_END_OF_WORD_BACKWARD:
-            end = [self.textStorage endOfWordsBackward:begin count:motion.count option:motion.option];
+            motion.option |= MOPT_PLACEHOLDER;
+            end = begin;
+            begin = [self.textStorage endOfWordsBackward:begin count:motion.count option:motion.option];
             break;
         case MOTION_LINE_FORWARD:
             if( motion.option & DISPLAY_LINE ){

--- a/XVim/Test/XVimTester+Motion.m
+++ b/XVim/Test/XVimTester+Motion.m
@@ -63,6 +63,10 @@
             XVimMakeTestCase(text2,  4, 0,   @"G", text2, 40, 0),
             XVimMakeTestCase(text2, 44, 0,  @"3G", text2, 24, 0),
             XVimMakeTestCase(text2,  8, 0,  @"9G", text2, 40, 0),
+
+            // gE
+            XVimMakeTestCase(text2,  9, 0, @"gE", text2, 6, 0),
+            XVimMakeTestCase(text2,  9, 0, @"2gE", text2, 2, 0),
             
             // h,j,k,l, <space>
             XVimMakeTestCase(text1, 0, 0,   @"l", text1, 1, 0),

--- a/XVim/Test/XVimTester+Motion.m
+++ b/XVim/Test/XVimTester+Motion.m
@@ -64,10 +64,13 @@
             XVimMakeTestCase(text2, 44, 0,  @"3G", text2, 24, 0),
             XVimMakeTestCase(text2,  8, 0,  @"9G", text2, 40, 0),
 
-            // gE
+            // ge, gE
             XVimMakeTestCase(text2,  9, 0, @"gE", text2, 6, 0),
             XVimMakeTestCase(text2,  9, 0, @"2gE", text2, 2, 0),
-            
+            XVimMakeTestCase(text2,  2, 0, @"gE", text2, 0, 0),
+            XVimMakeTestCase(text2,  2, 0, @"ge", text2, 1, 0),
+            XVimMakeTestCase(text2,  4, 0, @"2ge", text2, 1, 0),
+
             // h,j,k,l, <space>
             XVimMakeTestCase(text1, 0, 0,   @"l", text1, 1, 0),
             XVimMakeTestCase(text1, 0, 0, @"10l", text1, 2, 0),

--- a/XVim/Test/XVimTester+Visual.m
+++ b/XVim/Test/XVimTester+Visual.m
@@ -210,6 +210,12 @@
             XVimMakeTestCase(text4, 1, 0, @"<C-v>jjgJ"   , v_gJ_result0, 7, 0), // join 2 lines
             // XVimMakeTestCase(text4, 1, 0, @"<C-v>jjgJj." , v_gJ_result1,17, 0), // Repeat (not supported yet)
             XVimMakeTestCase(text4, 1, 0, @"<C-v>jjgJ`." , v_gJ_result0,11, 0), // . Mark
+
+            // ge, gE in visual
+            XVimMakeTestCase(text2, 18, 0, @"vge", text2, 17, 2),
+            XVimMakeTestCase(text2, 18, 0, @"vgE", text2, 14, 5),
+            XVimMakeTestCase(text2, 18, 0, @"v2ge", text2, 16, 3),
+            XVimMakeTestCase(text2, 18, 0, @"v2gE", text2, 10, 9),
             
             nil];
 }

--- a/XVim/XVimGMotionEvaluator.m
+++ b/XVim/XVimGMotionEvaluator.m
@@ -23,6 +23,12 @@
     return [super eval:keyStroke];
 }
 
+- (XVimEvaluator*)E{
+    // Select previous WORD end
+    self.motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_INCLUSIVE, BIGWORD, [self numericArg]);
+    return nil;
+}
+
 - (XVimEvaluator*)g{
     self.motion = XVIM_MAKE_MOTION(MOTION_LINENUMBER, LINEWISE, MOTION_OPTION_NONE, 1);
     self.motion.line = self.numericArg;
@@ -65,12 +71,6 @@
 - (XVimEvaluator*)SEMICOLON{
     // SEMICOLON is handled by parent evaluator (not really good design though)
     self.motion = nil;
-    return nil;
-}
-
-- (XVimEvaluator*)E{
-    // Select previous word end
-    self.motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_INCLUSIVE, BIGWORD, [self numericArg]);
     return nil;
 }
 

--- a/XVim/XVimGMotionEvaluator.m
+++ b/XVim/XVimGMotionEvaluator.m
@@ -23,6 +23,12 @@
     return [super eval:keyStroke];
 }
 
+- (XVimEvaluator*)e{
+    // Select previous word end
+    self.motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_INCLUSIVE, MOTION_OPTION_NONE, [self numericArg]);
+    return nil;
+}
+
 - (XVimEvaluator*)E{
     // Select previous WORD end
     self.motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_INCLUSIVE, BIGWORD, [self numericArg]);

--- a/XVim/XVimGMotionEvaluator.m
+++ b/XVim/XVimGMotionEvaluator.m
@@ -68,4 +68,10 @@
     return nil;
 }
 
+- (XVimEvaluator*)E{
+    // Select previous word end
+    self.motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_INCLUSIVE, BIGWORD, [self numericArg]);
+    return nil;
+}
+
 @end

--- a/XVim/XVimGVisualEvaluator.m
+++ b/XVim/XVimGVisualEvaluator.m
@@ -27,6 +27,20 @@
     [super didEndHandler];
 }
 
+- (XVimEvaluator*)e{
+    XVimMotion *motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_EXCLUSIVE, MOTION_OPTION_NONE, self.numericArg);
+    [[self sourceView] xvim_move:motion];
+    [self.parent resetNumericArg];
+    return [XVimEvaluator popEvaluator];
+}
+
+- (XVimEvaluator*)E{
+    XVimMotion *motion = XVIM_MAKE_MOTION(MOTION_END_OF_WORD_BACKWARD, CHARACTERWISE_EXCLUSIVE, BIGWORD, self.numericArg);
+    [[self sourceView] xvim_move:motion];
+    [self.parent resetNumericArg];
+    return [XVimEvaluator popEvaluator];
+}
+
 - (XVimEvaluator *)f{
     [self.window errorMessage:@"{visual}gf unimplemented" ringBell:NO];
     return [XVimEvaluator popEvaluator];


### PR DESCRIPTION
This Pull Requests adds support for backwards end word movement. I intend to mirror the behaviour apparent in Vim, with all its quirks.

### Behaviour

- `gE` goes to the end of the previous `WORD`
- `2gE` goes to end of the second-to-last `WORD`
- `ge` goes to the end of the previous `word`
- `2ge` goes to end of the second-to-last `word`
- `vge` selects from the current index to the end of the previous `word`
- `gE` sets the cursor to the beginning of the line if there are no word boundries. See below:

```
// [ ] cursor position
ab[c] def

// Type
gE

// Moves the cursor to the beginning of the line
[a]bc def
```

### TODO

- [x] implement `gE` in normal mode
- [x] allow word counts, e.g. '2gE' (go back 2 WORDS)
- [x] support `word`, e.g. `ge`
- [x] allow use in visual mode

This fixes #918.
