### PR TITLE
Add UUID for Xcode 7.3

### DIFF
--- a/XVim/Info.plist
+++ b/XVim/Info.plist
@@ -39,6 +39,7 @@
 		<string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>E71C2CFE-BFD8-4044-8F06-00AE685A406C</string>
+		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012 JugglerShu.Net. All rights reserved.</string>


### PR DESCRIPTION
Xcode 7.3 has been released today with a new UUID item.
