### PR TITLE
Hotfix for issue #251

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -2122,6 +2122,11 @@
 
 - (NSRect)xvim_boundingRectForGlyphIndex:(NSUInteger)glyphIndex {
 	NSRect glyphRect;
+    // Fix for issue #251
+    if (glyphIndex > self.textStorage.string.length) {
+        glyphIndex = self.textStorage.string.length;
+    }
+
 	if( [self.textStorage isEOF:glyphIndex] ){
 		// When the index is EOF the range to specify here can not be grater than 0. If it is greater than 0 it returns (0,0) as a glyph rect.
 		NSUInteger count;

--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -36,7 +36,10 @@
                                         @"ggg hhh i_i\n" 
                                         @"ddd e-e fff\n" 
                                         @"    jjj kkk";  
-    
+
+    static NSString* issue_251_result = @"a;a bbb ccc\n"
+                                        @"    jjj kkk";
+
     static NSString* issue_429_result = @"bbb bbb ccc\n";
     
     static NSString* issue_587 = @"test\n"
@@ -63,6 +66,7 @@
                                  @"ccc\n";// 2
      
     return [NSArray arrayWithObjects:
+            XVimMakeTestCase(text1, 12, 0, @"Vjd", issue_251_result , 16, 0),  // Issue #251
             XVimMakeTestCase(text0, 0, 0, @"qadwpq", @"baaa bb ccc\n", 4, 0),  // Issue #396
             XVimMakeTestCase(text1, 24, 0, @":inoremap <lt>C-e> <lt>C-o>$<CR>i<Right><Right><Up><Up><C-e><ESC>", text1 , 10, 0),  // Issue #416
             XVimMakeTestCase(text1, 20, 0, @"yyjp", issue_216_result, 36,0 ),


### PR DESCRIPTION
This is a hotfix for issue #251.

I'm unable to get the crash to happen while running tests, so I've had to manually test this using the following steps, using the latest `develop` branch in Xcode 7.3:

1. enter any file
2. hit `gg` to move to beginning of file
3. `V` to enter visual mode
4. hit `G` to move to the end of the file
5. hit `cmd+/` to comment the selected lines (every line in the file)
6. hit `esc` to exit visual mode
7. hit `gg` to move to beginning of file
8. `V` to enter visual mode
9. hit `G` to move to the end of the file
10. hit `cmd+/` to uncomment the selected lines
11. Xcode crashes with an out of bounds error

I experienced this crash when trying to delete a range towards the end of a file, but I'm unable to reproduce in the test environment, perhaps it only occurs when the file is reasonably large.

Before this commit there were 5 failing tests:

![before](https://cloud.githubusercontent.com/assets/343450/14139639/301eb336-f66c-11e5-80b7-3da0b053194c.png)

After this commit, the same 5 tests fail so I'm confident there are no regressions:

![after](https://cloud.githubusercontent.com/assets/343450/14139701/856f38ba-f66c-11e5-930a-fc5c75fb43f2.png)