### PR TITLE
Prevent "too many nested groupings" xcode crash on undo

### DIFF
--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -61,7 +61,8 @@
     static NSString* issue_865 = @"\n" // 0
                                  @"\n" // 1
                                  @"ccc\n";// 2
-     
+    static NSString* issue_951 = @"aaaa\n";
+    
     return [NSArray arrayWithObjects:
             XVimMakeTestCase(text0, 0, 0, @"qadwpq", @"baaa bb ccc\n", 4, 0),  // Issue #396
             XVimMakeTestCase(text1, 24, 0, @":inoremap <lt>C-e> <lt>C-o>$<CR>i<Right><Right><Up><Up><C-e><ESC>", text1 , 10, 0),  // Issue #416
@@ -89,6 +90,7 @@
             XVimMakeTestCase(issue_865 , 2, 0, @"2gg", issue_865, 1, 0), // Issue #865
             XVimMakeTestCase(issue_865 , 2, 0, @"2G", issue_865, 1, 0),  // Issue #865
             XVimMakeTestCase(issue_865 , 2, 0, @"G", issue_865, 6, 0),   // Issue #865
+            XVimMakeTestCase(issue_951 , 0, 0, @"r<cr>u", issue_951, 0, 0),   // Issue #951
             
             XVimMakeTestCase(text0, 0, 0, @":nmap <lt>backspace> l<cr><bs><bs>", text0, 2, 0), // Issue #844 mapping <backspace>
             nil];

--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -62,7 +62,7 @@
                                  @"\n" // 1
                                  @"ccc\n";// 2
     static NSString* issue_951 = @"aaaa\n";
-    
+
     return [NSArray arrayWithObjects:
             XVimMakeTestCase(text0, 0, 0, @"qadwpq", @"baaa bb ccc\n", 4, 0),  // Issue #396
             XVimMakeTestCase(text1, 24, 0, @":inoremap <lt>C-e> <lt>C-o>$<CR>i<Right><Right><Up><Up><C-e><ESC>", text1 , 10, 0),  // Issue #416

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -59,21 +59,17 @@
 - (void)didEndHandler {
     [super didEndHandler];
 
-    if (!_oneCharMode) {
-        NSUndoManager *undoManager = [[self sourceView] undoManager];
-        [undoManager endUndoGrouping];
-        [undoManager setGroupsByEvent:YES];
-    }
+    NSUndoManager *undoManager = [[self sourceView] undoManager];
+    [undoManager endUndoGrouping];
+    [undoManager setGroupsByEvent:YES];
 }
 
 - (void)becameHandler {
     [super becameHandler];
 
-    if (!_oneCharMode) {
-        NSUndoManager *undoManager = [[self sourceView] undoManager];
-        [undoManager setGroupsByEvent:NO];
-        [undoManager beginUndoGrouping];
-    }
+    NSUndoManager *undoManager = [[self sourceView] undoManager];
+    [undoManager setGroupsByEvent:NO];
+    [undoManager beginUndoGrouping];
 }
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{
@@ -95,7 +91,7 @@
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'
             if (self.oneCharMode || keyStroke.isPrintable) {
-                if (!keyStroke.isPrintable) {
+                if (!keyStroke.isPrintable && keyStroke.character != '\r') {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];
                 } else if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -59,17 +59,21 @@
 - (void)didEndHandler {
     [super didEndHandler];
 
-    NSUndoManager *undoManager = [[self sourceView] undoManager];
-    [undoManager endUndoGrouping];
-    [undoManager setGroupsByEvent:YES];
+    if (!_oneCharMode) {
+        NSUndoManager *undoManager = [[self sourceView] undoManager];
+        [undoManager endUndoGrouping];
+        [undoManager setGroupsByEvent:YES];
+    }
 }
 
 - (void)becameHandler {
     [super becameHandler];
 
-    NSUndoManager *undoManager = [[self sourceView] undoManager];
-    [undoManager setGroupsByEvent:NO];
-    [undoManager beginUndoGrouping];
+    if (!_oneCharMode) {
+        NSUndoManager *undoManager = [[self sourceView] undoManager];
+        [undoManager setGroupsByEvent:NO];
+        [undoManager beginUndoGrouping];
+    }
 }
 
 - (XVimEvaluator*)eval:(XVimKeyStroke*)keyStroke{


### PR DESCRIPTION
When 954f200 was introduced, I don't think it accounted for the fact that the undo handlers would get triggers for `r` as well as `R`, which I believe resulted in #817 being reported.

I unfortunately was not able to test. I added `set debug` to my config, restarted Xcode many times, and looked all over the menu for `XVim -> Run Test` but didn't see anything. I'd be more than happy if someone who can run the tests could piggyback on this PR and write a test and run it on my behalf.

Thanks!