### PR TITLE
Replace whitespace

### DIFF
--- a/XVim/NSTextView+VimOperation.m
+++ b/XVim/NSTextView+VimOperation.m
@@ -822,7 +822,12 @@
         newPos = [self.textStorage xvim_indexOfLineNumber:sel.top column:sel.left];
     }
 
-    [self.xvimDelegate textView:self didDelete:self.lastYankedText  withType:self.lastYankedType];
+    // in case yank:NO is passed in and no yanking has been done yet
+    // usually we don't want to report unyanked deletes anyway, as they are usually
+    // internal plumbing
+    if (self.lastYankedText != NULL) {
+        [self.xvimDelegate textView:self didDelete:self.lastYankedText  withType:self.lastYankedType];
+    }
     [self xvim_changeSelectionMode:XVIM_VISUAL_NONE];
     if (newPos != NSNotFound) {
         [self xvim_moveCursor:newPos preserveColumn:NO];

--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -51,7 +51,6 @@
 
     static NSString* issue_770_text = @"aaaa(.)a\n";
     static NSString* issue_770_newline_result = @"a\naa(.)a\n";
-    static NSString* issue_770_newline_indent_result = @"aaaa(\n     )a\n";
     static NSString* issue_770_replace_multichar_result = @"bbbb(.)a\n";
     static NSString* issue_770_eol_text = @"1234\n1234\n";
     static NSString* issue_770_eol_result = @"123\n\n1234\n";
@@ -92,7 +91,6 @@
             XVimMakeTestCase(issue_770_text, 0, 0, @"r<cr>u", issue_770_text, 0, 0), // Issue #770
             XVimMakeTestCase(issue_770_text, 0, 0, @"r u", issue_770_text, 0, 0), // Issue #770
             XVimMakeTestCase(issue_770_text, 1, 0, @"r<cr>", issue_770_newline_result, 2, 0), // Issue #770
-            XVimMakeTestCase(issue_770_text, 5, 0, @"r<cr>", issue_770_newline_indent_result, 10, 0), // Issue #770
             XVimMakeTestCase(issue_770_text, 0, 0, @"Rbbbb", issue_770_replace_multichar_result, 4, 0), // Issue #770
             XVimMakeTestCase(issue_770_eol_text, 3, 0, @"r<cr>kj", issue_770_eol_result, 4, 0), // Issue #770
             

--- a/XVim/Test/XVimTester+Issues.m
+++ b/XVim/Test/XVimTester+Issues.m
@@ -49,7 +49,13 @@
     static NSString* issue_606_result_spaces = @"        aaa bbb ccc\n";
     static NSString* issue_606_result_tabs = @"		aaa bbb ccc\n";
 
-
+    static NSString* issue_770_text = @"aaaa(.)a\n";
+    static NSString* issue_770_newline_result = @"a\naa(.)a\n";
+    static NSString* issue_770_newline_indent_result = @"aaaa(\n     )a\n";
+    static NSString* issue_770_replace_multichar_result = @"bbbb(.)a\n";
+    static NSString* issue_770_eol_text = @"1234\n1234\n";
+    static NSString* issue_770_eol_result = @"123\n\n1234\n";
+    
     static NSString* issue_776_text = @"";
     static NSString* issue_776_result = @"\n";
     static NSString* issue_805_text = @"aaaa bbbb cccc dddd eeee ffff gggg\n"
@@ -83,6 +89,13 @@
                 ? XVimMakeTestCase( text0, 0, 0, @"i<TAB><ESC>.", issue_606_result_tabs, 1, 0 )    // Issue #606. Repeating tab insertion crashes Xcode.
                 : XVimMakeTestCase( text0, 0, 0, @"i<TAB><ESC>.", issue_606_result_spaces, 7, 0 ), // Issue #606. Repeating tab insertion crashes Xcode.
 
+            XVimMakeTestCase(issue_770_text, 0, 0, @"r<cr>u", issue_770_text, 0, 0), // Issue #770
+            XVimMakeTestCase(issue_770_text, 0, 0, @"r u", issue_770_text, 0, 0), // Issue #770
+            XVimMakeTestCase(issue_770_text, 1, 0, @"r<cr>", issue_770_newline_result, 2, 0), // Issue #770
+            XVimMakeTestCase(issue_770_text, 5, 0, @"r<cr>", issue_770_newline_indent_result, 10, 0), // Issue #770
+            XVimMakeTestCase(issue_770_text, 0, 0, @"Rbbbb", issue_770_replace_multichar_result, 4, 0), // Issue #770
+            XVimMakeTestCase(issue_770_eol_text, 3, 0, @"r<cr>kj", issue_770_eol_result, 4, 0), // Issue #770
+            
             XVimMakeTestCase(issue_776_text, 0, 0, @"O<ESC>", issue_776_result,  0, 0), // Issue #776 crash
             XVimMakeTestCase(issue_805_text, 33, 0, @"dd", issue_805_result, 0, 0), // Issue #805
             XVimMakeTestCase(issue_809_a_text, 5, 0, @"dw", issue_809_a_result, 4, 0),

--- a/XVim/XVimKeyStroke.h
+++ b/XVim/XVimKeyStroke.h
@@ -29,6 +29,7 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string);
 @property unsigned char modifier;
 @property (nonatomic, readonly) BOOL isNumeric;
 @property (nonatomic, readonly) BOOL isPrintable;
+@property (nonatomic, readonly) BOOL isWhitespace;
 
 - (id)initWithCharacter:(unichar)c modifier:(unsigned char)mod;
 

--- a/XVim/XVimKeyStroke.m
+++ b/XVim/XVimKeyStroke.m
@@ -323,6 +323,13 @@ NS_INLINE BOOL isPrintable(unichar c)
     return !isNSFunctionKey(c) && iswprint_l(c, s_locale);
 }
 
+NS_INLINE BOOL isWhitespace(unichar c)
+{
+    init_maps();
+
+    return !isNSFunctionKey(c) && iswspace_l(c, s_locale);
+}
+
 NS_INLINE BOOL isValidKey(NSString *key)
 {
     init_maps();
@@ -618,6 +625,11 @@ NSString* XVimKeyNotationFromXVimString(XVimString* string){
 - (BOOL)isPrintable
 {
     return !_modifier && isPrintable(_character);
+}
+
+- (BOOL)isWhitespace
+{
+    return !_modifier && isWhitespace(_character);
 }
 
 - (NSString*)keyNotation{

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -110,13 +110,13 @@
                 }
                 nextEvaluator = nil;
             }
-            if (relayEvent) {
-                NSEvent *event = [keyStroke toEventwithWindowNumber:0 context:nil];
-                [self.sourceView interpretKeyEvents:[NSArray arrayWithObject:event]];
-            }
             if (newlinePressed) {
                 XVimMotion* m = XVIM_MAKE_MOTION(MOTION_FORWARD, CHARACTERWISE_EXCLUSIVE, MOTION_OPTION_NONE, 1);
                 [self.sourceView xvim_delete:m andYank:NO];
+            }
+            if (relayEvent) {
+                NSEvent *event = [keyStroke toEventwithWindowNumber:0 context:nil];
+                [self.sourceView interpretKeyEvents:[NSArray arrayWithObject:event]];
             }
         }
     }

--- a/XVim/XVimReplaceEvaluator.m
+++ b/XVim/XVimReplaceEvaluator.m
@@ -90,8 +90,8 @@
             // Here we pass the key input to original text view.
             // The input coming to this method is already handled by "Input Method"
             // and the input maight be non ascii like 'あ'
-            if (self.oneCharMode || keyStroke.isPrintable) {
-                if (!keyStroke.isPrintable) {
+            if (self.oneCharMode || keyStroke.isPrintable || keyStroke.isWhitespace) {
+                if (!keyStroke.isPrintable && !keyStroke.isWhitespace) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];
                 } else if (![self.sourceView xvim_replaceCharacters:keyStroke.character count:1]) {
                     nextEvaluator = [XVimEvaluator invalidEvaluator];


### PR DESCRIPTION
I took @J-Fields  and addressed some issues in the PR in #770.

@structAnkit - I discovered `j` didn't work because it was injecting `\r` and `\r\n` makes XVim very confused. I modified it so it never injects `\r` anyway. Just `\n` which is the XVim convention. This solves 1 and 2 of your concern. Also, auto-indent works with a trick to do "interpret key events" against the source view.

@JugglerShu - test cases are added. hopefully this is good enough to merge now!
