### PR TITLE
[draft] Fix for window navigation on xcode 8 beta 3

### DIFF
--- a/XVim/IDEWorkspaceTabController+XVim.m
+++ b/XVim/IDEWorkspaceTabController+XVim.m
@@ -62,9 +62,18 @@ static inline BOOL xvim_horizontallyStackingModeForMode(GeniusLayoutMode mode) {
 
 @implementation IDEWorkspaceTabController (XVim)
 
+- (id)xvim_keyboardFocusAreas {
+    if ([self respondsToSelector:@selector(_keyboardFocusAreas)]) {
+        return [self performSelector:@selector(_keyboardFocusAreas)];
+    } else if ([self respondsToSelector:@selector(_keyboardFocusAreas:)]) {
+        return [self performSelector:@selector(_keyboardFocusAreas:) withObject:@YES];
+    }
+    return nil;
+}
+
 - (NSArray*)xvim_allEditorArea{
     NSMutableArray* otherViews = [[NSMutableArray alloc] init];
-    for( IDEViewController* c in [self _keyboardFocusAreas] ){
+    for( IDEViewController* c in [self xvim_keyboardFocusAreas] ){
         if( [[[c class] description] isEqualToString:@"IDEEditorContext"] ){
             [otherViews addObject:c];
         }


### PR DESCRIPTION
- IDEWTC `_keyboardFocusAreas` had its signature changed to
  `_keyboardFocusAreas:`, so I'm just making a naive selector check to
  call the correct one.
- Would be nice to import the new headers and call the correct selector,
  but generating the header files seems to be troublesome (see issue #621).

Sharing this just as draft solution for people that want to use it temporarily.