### PR TITLE
Fixed a index out of bound error when trying to delete the first line…

### DIFF
--- a/XVim/NSTextStorage+VimOperation.m
+++ b/XVim/NSTextStorage+VimOperation.m
@@ -253,7 +253,7 @@ static NSUInteger xvim_sb_count_columns(xvim_string_buffer_t *sb, NSUInteger tab
         return NSNotFound;
     }
 
-    if (pos == index && isNewline([self.xvim_string characterAtIndex:(pos - 1)])) {
+    if (pos == index && pos > 0 && isNewline([self.xvim_string characterAtIndex:(pos - 1)])) {
         return NSNotFound;
     }
     return pos;


### PR DESCRIPTION
Fix a index out of bound error when deleting the first line of a document. The error comes from a case where pos is 0 and we are trying to access character at pos - 1, which is -1 but then overflows to MAX_UINT64 / MAX_UINT32 because pos is of type NSUIteger.

Notes to reviewers:

This is just a temporary fix to silent error. However, the nature of the issue extend beyond the index out of bound. The code is comparing pos against index, pos is a position in terms of characters but index is line the line number. It definitely feels wrong to compare them, but I was not able to figure out what the expected behavior is with my time constraints. So I'm going to leave that to those who are more familiar with the code.